### PR TITLE
Proof of concept: summarize after responding to user

### DIFF
--- a/Middleware/core/open_ai_api.py
+++ b/Middleware/core/open_ai_api.py
@@ -159,4 +159,4 @@ class WilmerApi:
         else:
             print("handle_user_prompt workflow exists")
             workflow_manager: WorkflowManager = WorkflowManager(get_active_custom_workflow_name())
-            return workflow_manager.run_workflow(prompt_collection, stream)
+            return workflow_manager.run_workflow(prompt_collection, stream, allow_generator=True)

--- a/Middleware/workflows/tools/slow_but_quality_rag_tool.py
+++ b/Middleware/workflows/tools/slow_but_quality_rag_tool.py
@@ -375,7 +375,9 @@ class SlowButQualityRAGTool:
         """
         print("Beginning full discussion flow")
         new_messages = deepcopy(messages)
-        if len(new_messages) > 1 and new_messages[-1]['role'] == 'assistant':
+        if (len(new_messages) > 1
+            and new_messages[-1]['role'] == 'assistant'
+            and len(new_messages[-1].get('content', '')) < 30):
             new_messages = new_messages[:-1]
 
         new_messages.reverse()

--- a/Public/Configs/Workflows/convoroleplaysinglemodeltemplate/FullCustomWorkflow-ChatSummary.json
+++ b/Public/Configs/Workflows/convoroleplaysinglemodeltemplate/FullCustomWorkflow-ChatSummary.json
@@ -1,12 +1,11 @@
 [
-  {
-    "title": "Checking AI's recent memory about this topic",
-    "agentName": "Chat Summary",
-    "type": "FullChatSummary",
-    "isManualConfig": true
-  },
-  {
-    "title": "Responding to User Request",
+   {
+    "title": "Grab the current summary from file",
+    "agentName": "Chat Summary File Puller Agent",
+    "type": "GetCurrentSummaryFromFile"
+   },
+   {
+    "title": "LLM Responding to User Request",
     "agentName": "Response Agent Five",
     "systemPrompt": "You are an exceptionally creative AI that specializes in user enjoyment, and you are currently engaged in a roleplay conversation with user via an online chat program.\n\nYou are role playing a character in this conversation. Below, within brackets, are the initial instructions for that role play, including the starting scenario:\n[\n{chat_system_prompt}\n]\n\nSince the roleplay began, some changes to the initial scenario may have occurred through natural progression. A summary of the roleplay's story up to now can be found here:\n[\n{agent1Output}\n]\n\nPlease continue the below conversation, acting out your character. Please do not write dialogue for the user's character, and please keep your own response concise so that the user can have an opportunity to respond as well.\n\nPlease continue the below conversation with a concise reply, continuing your character's roleplay.",
     "prompt": "",
@@ -14,6 +13,13 @@
     "endpointName": "ConvoRoleplaySingleModelEndpoint",
     "preset": "MidnightMiqu1.0_Recommended",
     "maxResponseSizeInTokens": 800,
-    "addUserTurnTemplate": false
-  }
+    "addUserTurnTemplate": false,
+    "returnToUser": true
+   },
+   {
+    "title": "Checking AI's recent memory about this topic",
+    "agentName": "Chat Summary",
+    "type": "FullChatSummary",
+    "isManualConfig": false
+    }
 ]


### PR DESCRIPTION
The roleplaysinglemodel custom chat summary workflow now runs in this order:

1. GetCurrentSummaryFromFile
2. Standard
3. FullChatSummary

After step 2 (during if streaming), the LLM's response is returned to the user, but the connection is kept open until step 3 completes.

I had to add an argument to `run_workflow`, because returning a generator is only allowed on one code path. Maybe reusing `stream` would suffice? SO comments say changing the return type based on an argument is an anti-pattern and the function contract should be stricter.

The changed order also means memories/summaries can use the assistant's response. I added a hard coded length based guess to determine if the last assistant message should be used, but this should be determined by the workflow order.