### PR TITLE
Removing responder node from chat summary/memory

### DIFF
--- a/Middleware/core/open_ai_api.py
+++ b/Middleware/core/open_ai_api.py
@@ -159,4 +159,4 @@ class WilmerApi:
         else:
             print("handle_user_prompt workflow exists")
             workflow_manager: WorkflowManager = WorkflowManager(get_active_custom_workflow_name())
-            return workflow_manager.run_workflow(prompt_collection, stream, allow_generator=True)
+            return workflow_manager.run_workflow(prompt_collection, stream)

--- a/Middleware/workflows/managers/workflow_manager.py
+++ b/Middleware/workflows/managers/workflow_manager.py
@@ -81,7 +81,7 @@ class WorkflowManager:
         if 'lookbackStartTurn' in kwargs:
             self.lookbackStartTurn = kwargs['lookbackStartTurn']
 
-    def run_workflow(self, user_prompt, stream: bool = False, allow_generator = False):
+    def run_workflow(self, user_prompt, stream: bool = False):
         """
         Executes the workflow based on the configuration file.
 
@@ -94,6 +94,7 @@ class WorkflowManager:
 
         with open(config_file) as f:
             configs = json.load(f)
+
         def gen():
             returned_to_user = False
             agent_outputs = {}
@@ -112,10 +113,6 @@ class WorkflowManager:
                         result = ''.join(text_chunks)
                     else:
                         yield result
-                    if user_prompt[-1]['role'] == 'assistant':
-                        user_prompt[-1]['content'] += result
-                    else:
-                        user_prompt.append({'role': 'assistant', 'content': result})
                     agent_outputs[f'agent{idx + 1}Output'] = result
                 else:
                     agent_outputs[f'agent{idx + 1}Output'] = self._process_section(config, user_prompt, agent_outputs)
@@ -124,7 +121,7 @@ class WorkflowManager:
             execution_time = end_time - start_time
             print(f"Execution time: {execution_time} seconds")
 
-        if allow_generator and stream:
+        if stream:
             return gen()
         else:
             exhaust_generator = [x for x in gen()]

--- a/Middleware/workflows/managers/workflow_manager.py
+++ b/Middleware/workflows/managers/workflow_manager.py
@@ -108,8 +108,6 @@ class WorkflowManager:
                         text_chunks = []
                         for chunk in result:
                             if chunk.strip() != '[DONE]' and chunk.strip() != 'data: [DONE]':
-                                print("Chunk yield is: ", chunk)
-                                print("Yielding chunk from node:", idx, chunk)
                                 text_chunks.append(json.loads(chunk.removeprefix('data:'))['choices'][0]['text'])
                                 yield chunk
                             else:

--- a/Middleware/workflows/managers/workflow_manager.py
+++ b/Middleware/workflows/managers/workflow_manager.py
@@ -107,9 +107,13 @@ class WorkflowManager:
                     if stream:
                         text_chunks = []
                         for chunk in result:
-                            chunk_data = json.loads(chunk.removeprefix('data:'))
-                            text_chunks.append(chunk_data['choices'][0]['text'])
-                            yield chunk
+                            if chunk.strip() != '[DONE]' and chunk.strip() != 'data: [DONE]':
+                                print("Chunk yield is: ", chunk)
+                                print("Yielding chunk from node:", idx, chunk)
+                                text_chunks.append(json.loads(chunk.removeprefix('data:'))['choices'][0]['text'])
+                                yield chunk
+                            else:
+                                yield chunk
                         result = ''.join(text_chunks)
                     else:
                         yield result


### PR DESCRIPTION
Removed the responder node response from being logged as a memory or chat summary. Also removed the allow_generator boolean; streaming responses aren't utilized internally for anything, so if I was reading that right then I think it's fine to just check stream.