### PR TITLE
Allowing use of timestamps on messages, and major improvements to memories and summary

### DIFF
--- a/Middleware/utilities/config_utils.py
+++ b/Middleware/utilities/config_utils.py
@@ -150,6 +150,18 @@ def get_discussion_file_path(discussion_id, file_name):
     return os.path.join(directory, f'{discussion_id}_{file_name}.json')
 
 
+def get_discussion_timestamp_file_path(discussion_id):
+    """
+    Constructs the file path for a discussion-related file.
+
+    :param discussion_id: The ID of the discussion.
+    :param file_name: The base name of the file.
+    :return: The full path to the discussion file.
+    """
+    directory = get_config_value('discussionDirectory')
+    return os.path.join(directory, f'{discussion_id}_timestamps.json')
+
+
 def get_custom_dblite_filepath():
     """
     Pulls the custom directory to put the dblite values, if specified.

--- a/Middleware/utilities/file_utils.py
+++ b/Middleware/utilities/file_utils.py
@@ -1,5 +1,6 @@
 import json
 import os
+from typing import Dict
 
 
 def ensure_json_file_exists(filepath, initial_data=None):
@@ -87,3 +88,21 @@ def get_logger_filename():
     middleware_dir = os.path.dirname(util_dir)
     project_dir = os.path.dirname(middleware_dir)
     return os.path.join(project_dir, "logs", 'wilmerai.log')
+
+
+def load_timestamp_file(filepath: str) -> Dict[str, str]:
+    """Load the timestamp file if it exists, otherwise return an empty dictionary."""
+    if os.path.exists(filepath):
+        print(f"File exists: {filepath}")
+        with open(filepath, 'r') as file:
+            print(f"Opening file: {filepath}")
+            return json.load(file)
+    else:
+        print(f"File does not exist: {filepath}")
+        return {}
+
+
+def save_timestamp_file(filepath: str, timestamps: Dict[str, str]):
+    """Save the timestamp data to the appropriate file."""
+    with open(filepath, 'w') as file:
+        json.dump(timestamps, file, indent=4)

--- a/Middleware/utilities/memory_utils.py
+++ b/Middleware/utilities/memory_utils.py
@@ -1,0 +1,233 @@
+from copy import deepcopy
+from typing import Dict, List, Any, Tuple
+
+from Middleware.utilities import text_utils
+from Middleware.utilities.config_utils import get_discussion_memory_file_path, get_discussion_chat_summary_file_path
+from Middleware.utilities.file_utils import read_chunks_with_hashes
+from Middleware.utilities.prompt_utils import extract_text_blocks_from_hashed_chunks, \
+    find_how_many_new_memories_since_last_summary
+
+
+def gather_chat_summary_memories(messages: List[Dict[str, str]], discussion_id: str,
+                                 max_turns_to_pull: int = 0):
+    """
+    Gathers chat summary memories from the conversation based on the specified limits.
+
+    :param messages: The list of messages in the conversation.
+    :param max_turns_to_pull: The maximum number of turns to pull from the conversation (default: 0).
+    :return: A list of tuples containing the chat summary memories.
+    """
+    return get_chat_summary_memories(
+        messages=messages,
+        discussion_id=discussion_id,
+        max_turns_to_search=max_turns_to_pull
+    )
+
+
+def gather_recent_memories(messages: List[Dict[str, str]], discussion_id: str, max_turns_to_pull=0,
+                           max_summary_chunks_from_file=0) -> Any:
+    """
+        Gathers recent memories from the conversation based on the specified limits.
+
+        :param messages: The list of messages in the conversation.
+        :param max_turns_to_pull: The maximum number of turns to pull from the conversation (default: 0).
+        :param max_summary_chunks_from_file: The maximum number of summary chunks to pull from the file (default: 0).
+        :return: A list of recent memories.
+    """
+    return get_recent_memories(
+        messages=messages,
+        max_turns_to_search=max_turns_to_pull,
+        max_summary_chunks_from_file=max_summary_chunks_from_file,
+        discussion_id=discussion_id
+    )
+
+
+def get_recent_memories(messages: List[Dict[str, str]], discussion_id: str, max_turns_to_search=0,
+                        max_summary_chunks_from_file=0) -> str:
+    """
+    Retrieves recent memories from chat messages or memory files.
+
+    Args:
+        messages (List[Dict[str, str]]): The list of recent chat messages.
+        max_turns_to_search (int): Maximum turns to search in the chat history.
+        max_summary_chunks_from_file (int): Maximum summary chunks to retrieve from memory files.
+
+    Returns:
+        str: The recent memories concatenated as a single string with '--ChunkBreak--' delimiter.
+    """
+    print("Entered get_recent_memories")
+
+    if discussion_id is None:
+        final_pairs = get_recent_chat_messages_up_to_max(max_turns_to_search, messages)
+        print("Recent Memory complete. Total number of pair chunks: {}".format(len(final_pairs)))
+        return '--ChunkBreak--'.join(final_pairs)
+    else:
+        filepath = get_discussion_memory_file_path(discussion_id)
+        hashed_chunks = read_chunks_with_hashes(filepath)
+        if len(hashed_chunks) == 0:
+            final_pairs = get_recent_chat_messages_up_to_max(max_turns_to_search, messages)
+            return '--ChunkBreak--'.join(final_pairs)
+        else:
+            chunks = extract_text_blocks_from_hashed_chunks(hashed_chunks)
+            if max_summary_chunks_from_file == 0:
+                max_summary_chunks_from_file = 3
+            elif max_summary_chunks_from_file == -1:
+                return '--ChunkBreak--'.join(chunks)
+            elif len(chunks) <= max_summary_chunks_from_file:
+                return '--ChunkBreak--'.join(chunks)
+
+            latest_summaries = chunks[-max_summary_chunks_from_file:]
+            return '--ChunkBreak--'.join(latest_summaries)
+
+
+def get_latest_memory_chunks_with_hashes_since_last_summary(discussion_id: str) -> List[Tuple[str, str]]:
+    """
+    Retrieves memory chunks and their corresponding hashes from the memory file, starting from the last processed
+    memory hash in the summary file.
+
+    Args:
+        discussion_id (str): The discussion ID.
+
+    Returns:
+        List[Tuple[str, str]]: A list of tuples where each tuple is (hash, memory chunk).
+    """
+    # Fetch memory and summary file paths
+    memory_filepath = get_discussion_memory_file_path(discussion_id)
+    summary_filepath = get_discussion_chat_summary_file_path(discussion_id)
+
+    # Get all memory chunks with hashes
+    all_memory_chunks = read_chunks_with_hashes(memory_filepath)  # Returns [(hash, chunk), ...]
+
+    # If no memory chunks exist, return an empty list
+    if not all_memory_chunks:
+        return []
+
+    # Get the last used hash from the summary file
+    summary_chunks = read_chunks_with_hashes(summary_filepath)  # Returns [(hash, chunk), ...]
+
+    # If the summary file exists and has chunks, find the last matching hash
+    if summary_chunks:
+        last_used_hash = summary_chunks[-1][1]  # The hash of the last summary
+
+        # Find the index of the last used memory chunk
+        last_used_index_from_end = find_how_many_new_memories_since_last_summary(summary_chunks, all_memory_chunks)
+        print("Finding last memory chunk for summary. Index from end is: {}".format(last_used_index_from_end))
+
+        # If a match is found
+        if last_used_index_from_end is not None:
+            # Calculate the correct index in the memory array
+            actual_index = len(all_memory_chunks) - last_used_index_from_end
+            print("Calculated actual index: {}".format(actual_index))
+
+            # If the last used memory is the last item in all_memory_chunks, return an empty list
+            if actual_index == len(all_memory_chunks):
+                print("All memories are up to date. Returning empty array.")
+                return []
+
+            # Otherwise, return only the chunks after the last used memory
+            print("Returning new memory chunks starting from index: {}".format(actual_index))
+            return all_memory_chunks[actual_index:]
+
+    # If no matching hash is found, or the summary file is empty, return all memory chunks
+    print("No matching memory chunk found in summary. Returning all chunks.")
+    return all_memory_chunks
+
+
+def get_chat_summary_memories(messages: List[Dict[str, str]], discussion_id: str, max_turns_to_search=0) -> str:
+    """
+    Retrieves chat summary memories from messages or memory files.
+
+    Args:
+        messages (List[Dict[str, str]]): The list of recent chat messages.
+        max_turns_to_search (int): Maximum turns to search in the chat history.
+
+    Returns:
+        str: The chat summary memories concatenated as a single string with '--ChunkBreak--' delimiter.
+    """
+    print("Entered get_chat_summary_memories")
+
+    # If no discussion ID is provided, fall back to recent chat messages
+    if discussion_id is None:
+        final_pairs = get_recent_chat_messages_up_to_max(max_turns_to_search, messages)
+        print(f"Chat Summary memory gathering complete. Total number of pair chunks: {len(final_pairs)}")
+        return '\n------------\n'.join(final_pairs)
+
+    # Use the new method to get memory chunks with hashes after the last summary
+    memory_chunks_with_hashes = get_latest_memory_chunks_with_hashes_since_last_summary(discussion_id)
+
+    # If no memory chunks are found, return an empty string
+    if not memory_chunks_with_hashes:
+        print("[DEBUG] No memory chunks found, returning an empty string.")
+        return ''
+
+    # Concatenate only the memory chunks (ignoring hashes)
+    memory_chunks = [chunk for _, chunk in memory_chunks_with_hashes]
+
+    return '\n------------\n'.join(memory_chunks)
+
+
+def get_recent_chat_messages_up_to_max(max_turns_to_search: int, messages: List[Dict[str, str]]) -> List[str]:
+    """
+    Retrieves recent chat messages up to a maximum number of turns to search.
+
+    Args:
+        max_turns_to_search (int): Maximum number of turns to search in the chat history.
+        messages (List[Dict[str, str]]): The list of recent chat messages.
+
+    Returns:
+        List[str]: The recent chat messages as a list of chunks.
+    """
+    if len(messages) <= 1:
+        print("No memory chunks")
+        return []
+
+    print("Number of pairs: " + str(len(messages)))
+
+    # Take the last max_turns_to_search number of pairs from the collection
+    message_copy = deepcopy(messages)
+    if max_turns_to_search > 0:
+        message_copy = message_copy[-min(max_turns_to_search, len(message_copy)):]
+
+    print("Max turns to search: " + str(max_turns_to_search))
+    print("Number of pairs: " + str(len(message_copy)))
+
+    pair_chunks = text_utils.get_message_chunks(message_copy, 0, 400)
+    filtered_chunks = [s for s in pair_chunks if s]
+
+    final_pairs = text_utils.clear_out_user_assistant_from_chunks(filtered_chunks)
+
+    return final_pairs
+
+
+def handle_get_current_summary_from_file(discussion_id: str):
+    """
+    Retrieves the current summary from a file based on the user's prompt.
+
+    :param discussion_id: Discussion id used for memories and chat summary
+    :return: The current summary extracted from the file or a message indicating the absence of a summary file.
+    """
+    filepath = get_discussion_chat_summary_file_path(discussion_id)
+
+    current_summary = read_chunks_with_hashes(filepath)
+
+    if current_summary is None or len(current_summary) == 0:
+        return "There is not yet a summary file"
+
+    return extract_text_blocks_from_hashed_chunks(current_summary)[0]
+
+
+def handle_get_current_memories_from_file(discussion_id):
+    """
+    Retrieves the current summary from a file based on the user's prompt.
+
+    :param discussion_id: Discussion id used for memories and chat summary
+    :return: The current summary extracted from the file or a message indicating the absence of a summary file.
+    """
+    filepath = get_discussion_memory_file_path(discussion_id)
+
+    current_memories = read_chunks_with_hashes(filepath)
+
+    if current_memories is None or len(current_memories) == 0:
+        return "There are not yet any memories"
+
+    return extract_text_blocks_from_hashed_chunks(current_memories)

--- a/Middleware/utilities/prompt_template_utils.py
+++ b/Middleware/utilities/prompt_template_utils.py
@@ -104,6 +104,26 @@ def format_user_turn_with_template(user_turn: str, template_file_name: str, isCh
     return strip_tags(formatted_turn)
 
 
+def format_assistant_turn_with_template(assistant_turn: str, template_file_name: str, isChatCompletion: bool) -> str:
+    """
+    Formats a single assistant turn using the specified template, but without an ending tag. This is
+    for forcing a completion.
+
+    Parameters:
+    - assistant_turn (str): The assistant's message to be formatted and completed.
+    - template_file_name (str): The name of the template file to use for formatting.
+
+    Returns:
+    - str: The formatted user turn.
+    """
+    if (isChatCompletion):
+        return strip_tags(assistant_turn)
+
+    prompt_template = load_template_from_json(template_file_name)
+    formatted_turn = f"{prompt_template['promptTemplateAssistantPrefix']}{assistant_turn}"
+    return strip_tags(formatted_turn)
+
+
 def format_system_prompt_with_template(system_prompt: str, template_file_name: str, isChatCompletion: bool) -> str:
     """
     Formats a system prompt using the specified template.

--- a/Middleware/utilities/prompt_utils.py
+++ b/Middleware/utilities/prompt_utils.py
@@ -52,7 +52,8 @@ def strip_tags(input_string: str) -> str:
 
 
 def chunk_messages_with_hashes(messages: List[Dict[str, str]], chunk_size: int = 500,
-                               use_first_message_hash: bool = False) -> List[Tuple[str, str]]:
+                               use_first_message_hash: bool = False, max_messages_before_chunk: int = 0) -> List[
+    Tuple[str, str]]:
     """
     Chunk messages into blocks of a maximum token size and hash either the last or first message.
 
@@ -70,7 +71,8 @@ def chunk_messages_with_hashes(messages: List[Dict[str, str]], chunk_size: int =
     List[Tuple[str, str]]: A list of tuples, each containing a text block and the hash of the first/last message.
     """
     print("In chunk messages with hash")
-    chunked_messages = chunk_messages_by_token_size(messages, chunk_size)
+    print("max_messages_before_chunk: " + str(max_messages_before_chunk))
+    chunked_messages = chunk_messages_by_token_size(messages, chunk_size, max_messages_before_chunk)
 
     # Adjust whether we hash the first or last message based on the boolean flag
     return [(messages_to_text_block(chunk), hash_single_message(chunk[0] if use_first_message_hash else chunk[-1]))
@@ -147,8 +149,8 @@ def find_last_matching_hash_message(messagesOriginal: List[Dict[str, str]],
     return len(current_message_hashes)  # If no match found, return the total number of messages
 
 
-def find_last_matching_memory_hash(hashed_summary_chunk: Optional[List[Tuple[str, str]]],
-                                   hashed_memory_chunks: List[Tuple[str, str]]) -> int:
+def find_how_many_new_memories_since_last_summary(hashed_summary_chunk: Optional[List[Tuple[str, str]]],
+                                                  hashed_memory_chunks: List[Tuple[str, str]]) -> int:
     """
     Find the index of the last hashed summary chunk that matches any hash in the hashed memory chunks.
 
@@ -159,10 +161,16 @@ def find_last_matching_memory_hash(hashed_summary_chunk: Optional[List[Tuple[str
     Returns:
     int: The index of the last matching memory hash, or -1 if no match is found.
     """
-    if not hashed_summary_chunk or not hashed_memory_chunks:
+    if not hashed_memory_chunks:
         return -1
-    summary_hash = hashed_summary_chunk[0][1]
+
+    if not hashed_summary_chunk:
+        return len(hashed_memory_chunks)
+
+    summary_hash = hashed_summary_chunk[-1][1]
+
     memory_hashes = [hash_tuple[1] for hash_tuple in hashed_memory_chunks]
+
     return memory_hashes[::-1].index(summary_hash) if summary_hash in memory_hashes else -1
 
 

--- a/Middleware/utilities/time_tracking_utils.py
+++ b/Middleware/utilities/time_tracking_utils.py
@@ -1,0 +1,122 @@
+from datetime import datetime, timedelta
+from typing import List, Dict
+
+from Middleware.utilities.config_utils import get_discussion_timestamp_file_path
+from Middleware.utilities.file_utils import load_timestamp_file, save_timestamp_file
+from Middleware.utilities.prompt_utils import hash_single_message
+
+
+def _current_timestamp() -> str:
+    """Return the current timestamp with the day of the week, wrapped in parentheses."""
+    return "(" + datetime.now().strftime("%A, %Y-%m-%d %H:%M:%S") + ")"
+
+
+def _add_seconds_to_timestamp(timestamp_str: str, seconds: int) -> str:
+    """Add a specific number of seconds to a timestamp string."""
+    timestamp = datetime.strptime(timestamp_str, "(%A, %Y-%m-%d %H:%M:%S)")
+    new_timestamp = timestamp + timedelta(seconds=seconds)
+    return "(" + new_timestamp.strftime("%A, %Y-%m-%d %H:%M:%S") + ")"
+
+
+def _subtract_minutes_from_timestamp(minutes: int) -> str:
+    """Return the current timestamp minus the specified number of minutes."""
+    return "(" + (datetime.now() - timedelta(minutes=minutes)).strftime("%A, %Y-%m-%d %H:%M:%S") + ")"
+
+
+def track_message_timestamps(messages: List[Dict[str, str]], discussion_id: str) -> List[Dict[str, str]]:
+    """
+    Track timestamps for messages, append timestamps where known, and update timestamps
+    for the two most recent messages, handling third-to-last if needed, and handle
+    cases for new conversations.
+
+    Parameters:
+    - messages (List[Dict[str, str]]): List of messages containing role and content.
+    - discussion_id (str): The ID of the discussion.
+
+    Returns:
+    - List[Dict[str, str]]: The updated list of messages with timestamps appended where applicable.
+    """
+
+    print("Processing timestamps")
+
+    # Load or initialize the timestamp file
+    timestamp_file = get_discussion_timestamp_file_path(discussion_id)
+    timestamps = load_timestamp_file(timestamp_file)
+
+    # Track if any updates to timestamps were made
+    timestamps_updated = False
+
+    # Track the hashes of non-system messages
+    message_hashes = []
+    for message in messages:
+        if message['role'] not in ['system', 'sysmes']:
+            message_hashes.append(hash_single_message(message))
+        else:
+            message_hashes.append(None)  # For system messages, we add None
+
+    # Add timestamps to known messages
+    for idx, message in enumerate(messages):
+        if message_hashes[idx] in timestamps:
+            # Add the timestamp to the beginning of the content if it exists
+            message['content'] = f"{timestamps[message_hashes[idx]]} {message['content']}"
+
+    # Handle the last three non-system messages
+    non_system_messages = [
+        i for i, message in enumerate(messages) if message['role'] not in ['system', 'sysmes']
+    ]
+
+    # Handle a new conversation with 3 messages and no timestamps on the first two
+    if len(non_system_messages) >= 3 and message_hashes[non_system_messages[0]] not in timestamps and message_hashes[
+        non_system_messages[1]] not in timestamps:
+        oldest_idx = non_system_messages[0]  # Oldest message (AI's first message)
+        second_to_last_idx = non_system_messages[1]  # User's response
+
+        # Add current timestamp - 2 minutes to the oldest message (AI's first message)
+        oldest_time = _subtract_minutes_from_timestamp(2)
+        messages[oldest_idx]['content'] = f"{oldest_time} {messages[oldest_idx]['content']}"
+        timestamps[message_hashes[oldest_idx]] = oldest_time
+        timestamps_updated = True
+
+        # Add current timestamp to the second-to-last message (User's response)
+        second_time = _current_timestamp()
+        messages[second_to_last_idx]['content'] = f"{second_time} {messages[second_to_last_idx]['content']}"
+        timestamps[message_hashes[second_to_last_idx]] = second_time
+        timestamps_updated = True
+
+    # Handle the case for conversations with more than 3 messages
+    if len(non_system_messages) >= 4:
+        fourth_last_idx = non_system_messages[-4] if len(non_system_messages) > 3 else None
+        third_last_idx = non_system_messages[-3]
+        second_last_idx = non_system_messages[-2]
+        last_idx = non_system_messages[-1]
+
+        current_time = _current_timestamp()
+
+        # Add current timestamp to the second-to-last message (if not already timestamped)
+        if message_hashes[second_last_idx] not in timestamps:
+            messages[second_last_idx]['content'] = f"{current_time} {messages[second_last_idx]['content']}"
+            timestamps[message_hashes[second_last_idx]] = current_time  # Store in the file
+            timestamps_updated = True  # Mark that we updated the timestamps
+
+        # Add current timestamp to the last message but do not store in file
+        if message_hashes[last_idx] not in timestamps:
+            messages[last_idx]['content'] = f"{current_time} {messages[last_idx]['content']}"
+
+        # Now, check the third-to-last message and backfill if needed
+        if message_hashes[third_last_idx] not in timestamps and fourth_last_idx:
+            # If the fourth-to-last message (your message from last round) has a timestamp
+            if message_hashes[fourth_last_idx] in timestamps:
+                user_last_round_timestamp = timestamps[message_hashes[fourth_last_idx]]
+                llm_timestamp = _add_seconds_to_timestamp(user_last_round_timestamp, 10)
+                messages[third_last_idx]['content'] = f"{llm_timestamp} {messages[third_last_idx]['content']}"
+                timestamps[message_hashes[third_last_idx]] = llm_timestamp  # Store in the file
+                timestamps_updated = True  # Mark that we updated the timestamps
+
+    # Only save to the file if any changes were made
+    if timestamps_updated:
+        save_timestamp_file(timestamp_file, timestamps)
+
+    print("Timestamp messages output:")
+    print(messages)
+
+    return messages

--- a/Middleware/workflows/managers/workflow_variable_manager.py
+++ b/Middleware/workflows/managers/workflow_variable_manager.py
@@ -4,6 +4,7 @@ from typing import Dict, Any, Optional, List
 import jinja2
 
 from Middleware.utilities.config_utils import get_chat_template_name
+from Middleware.utilities.memory_utils import handle_get_current_summary_from_file, gather_chat_summary_memories
 from Middleware.utilities.prompt_extraction_utils import extract_last_n_turns_as_string
 from Middleware.utilities.prompt_template_utils import (
     format_system_prompts, format_templated_prompt, get_formatted_last_n_turns_as_string
@@ -172,4 +173,19 @@ class WorkflowVariableManager:
                 isChatCompletion=llm_handler.takes_message_collection),
             "chat_user_prompt_last_one": extract_last_n_turns_as_string(messages, 1,
                                                                         include_sysmes, remove_all_system_override)
+        }
+
+    @staticmethod
+    def generate_chat_summary_variables(messages, discussion_id) -> Dict[str, str]:
+        """
+        Generates the variables used for pulling the chat summary.
+
+        :param originalMessages: The conversation turns.
+        :param llm_handler: The LLM handler.
+        :return: A dictionary of variables for user prompts at different turn lengths.
+        """
+        return {
+            "newest_chat_summary_memories": gather_chat_summary_memories(messages,
+                                                                         discussion_id),
+            "current_chat_summary": handle_get_current_summary_from_file(discussion_id)
         }

--- a/Middleware/workflows/tools/offline_wikipedia_api_tool.py
+++ b/Middleware/workflows/tools/offline_wikipedia_api_tool.py
@@ -9,7 +9,7 @@ class OfflineWikiApiClient:
     (https://github.com/SomeOddCodeGuy/OfflineWikipediaTextApi).
     """
 
-    def __init__(self):
+    def __init__(self, activateWikiApi=False, baseurl='127.0.0.1', port=5728):
         """
         Initialize the OfflineWikiApiClient.
 
@@ -18,8 +18,8 @@ class OfflineWikiApiClient:
         and port for API requests. Defaults to default of the API project.
         """
         config = get_user_config()
-        self.use_offline_wiki_api = config.get('useOfflineWikiApi', False)
-        self.base_url = f"http://{config.get('offlineWikiApiHost', '127.0.0.1')}:{config.get('offlineWikiApiPort', 5728)}"
+        self.use_offline_wiki_api = config.get('useOfflineWikiApi', activateWikiApi)
+        self.base_url = f"http://{config.get('offlineWikiApiHost', baseurl)}:{config.get('offlineWikiApiPort', port)}"
 
     def get_full_article_by_title(self, title):
         """

--- a/Public/Configs/PromptTemplates/chatml.json
+++ b/Public/Configs/PromptTemplates/chatml.json
@@ -5,5 +5,7 @@
   "promptTemplateSystemPrefix": "<|im_start|>system\n",
   "promptTemplateSystemSuffix": "<|im_end|>\n",
   "promptTemplateUserPrefix": "<|im_start|>user\n",
-  "promptTemplateUserSuffix": "<|im_end|>\n"
+  "promptTemplateUserSuffix": "<|im_end|>\n",
+  "promptTemplateSystemmesPrefix": "<|im_start|>system\n",
+  "promptTemplateSystemmesSuffix": "<|im_end|>\n"
 }

--- a/Public/Configs/PromptTemplates/command-r.json
+++ b/Public/Configs/PromptTemplates/command-r.json
@@ -1,9 +1,11 @@
 {
-  "promptTemplateSystemPrefix": "<BOS_TOKEN><|START_OF_TURN_TOKEN|><|SYSTEM_TOKEN|>",
-  "promptTemplateSystemSuffix": "<|END_OF_TURN_TOKEN|>",
+  "promptTemplateSystemPrefix": "<|START_OF_TURN_TOKEN|><|SYSTEM_TOKEN|>",
+  "promptTemplateSystemSuffix": "<|END_OF_TURN_TOKEN|>\n",
   "promptTemplateUserPrefix": "<|START_OF_TURN_TOKEN|><|USER_TOKEN|>",
-  "promptTemplateUserSuffix": "<|END_OF_TURN_TOKEN|>",
+  "promptTemplateUserSuffix": "<|END_OF_TURN_TOKEN|>\n",
   "promptTemplateAssistantPrefix": "<|START_OF_TURN_TOKEN|><|CHATBOT_TOKEN|>",
-  "promptTemplateAssistantSuffix": "<|END_OF_TURN_TOKEN|>",
+  "promptTemplateAssistantSuffix": "<|END_OF_TURN_TOKEN|>\n",
+  "promptTemplateSystemmesPrefix": "<|START_OF_TURN_TOKEN|><|SYSTEM_TOKEN|>",
+  "promptTemplateSystemmesSuffix": "<|END_OF_TURN_TOKEN|>\n",
   "promptTemplateEndToken": ""
 }

--- a/Public/Configs/PromptTemplates/mistral.json
+++ b/Public/Configs/PromptTemplates/mistral.json
@@ -1,9 +1,11 @@
 {
   "promptTemplateSystemPrefix": "",
-  "promptTemplateSystemSuffix": "",
+  "promptTemplateSystemSuffix": "[/INST]",
   "promptTemplateUserPrefix": "[INST]",
   "promptTemplateUserSuffix": "[/INST]",
-  "promptTemplateAssistantPrefix": "\n",
+  "promptTemplateAssistantPrefix": " ",
   "promptTemplateAssistantSuffix": "",
-  "promptTemplateEndToken": ""
+  "promptTemplateEndToken": "",
+  "promptTemplateSystemmesPrefix": "[INST] ",
+  "promptTemplateSystemmesSuffix": "[/INST]"
 }

--- a/Public/Configs/PromptTemplates/userassistantwizard.json
+++ b/Public/Configs/PromptTemplates/userassistantwizard.json
@@ -1,9 +1,9 @@
 {
-  "promptTemplateSystemPrefix": "",
+  "promptTemplateSystemPrefix": "BEGINNING OF CONVERSATION:\n",
   "promptTemplateSystemSuffix": " ",
-  "promptTemplateUserPrefix": "USER: ",
+  "promptTemplateUserPrefix": "\nUSER: ",
   "promptTemplateUserSuffix": " ",
-  "promptTemplateAssistantPrefix": "ASSISTANT: ",
+  "promptTemplateAssistantPrefix": "\nASSISTANT: ",
   "promptTemplateAssistantSuffix": "</s>",
   "promptTemplateEndToken": ""
 }

--- a/Public/Configs/Workflows/assistant-multi-model/CodingWorkflow-LargeModel-Centric.json
+++ b/Public/Configs/Workflows/assistant-multi-model/CodingWorkflow-LargeModel-Centric.json
@@ -8,6 +8,7 @@
     "endpointName": "Assistant-Multi-Model-Coding-Endpoint",
     "preset": "_Assistant_Multi_Model_Coder_Preset",
     "maxResponseSizeInTokens": 3000,
-    "addUserTurnTemplate": false
+    "addUserTurnTemplate": false,
+    "addDiscussionIdTimestampsForLLM": false
   }
 ]

--- a/Public/Configs/Workflows/assistant-multi-model/CodingWorkflow-MultiModel-Centric.json
+++ b/Public/Configs/Workflows/assistant-multi-model/CodingWorkflow-MultiModel-Centric.json
@@ -41,6 +41,7 @@
     "endpointName": "Assistant-Multi-Model-Coding-Endpoint",
     "preset": "_Assistant_Multi_Model_Coder_Preset",
     "maxResponseSizeInTokens": 2000,
-    "addUserTurnTemplate": false
+    "addUserTurnTemplate": false,
+    "addDiscussionIdTimestampsForLLM": false
   }
 ]

--- a/Public/Configs/Workflows/assistant-multi-model/ConversationalWorkflow-New.json
+++ b/Public/Configs/Workflows/assistant-multi-model/ConversationalWorkflow-New.json
@@ -15,6 +15,7 @@
     "preset": "_Assistant_Multi_Model_Conversational_Preset",
     "maxResponseSizeInTokens": 800,
     "addUserTurnTemplate": false,
-    "forceGenerationPromptIfEndpointAllows": false
+    "forceGenerationPromptIfEndpointAllows": false,
+    "addDiscussionIdTimestampsForLLM": false
   }
 ]

--- a/Public/Configs/Workflows/assistant-multi-model/ConversationalWorkflow-WorkflowLocked.json
+++ b/Public/Configs/Workflows/assistant-multi-model/ConversationalWorkflow-WorkflowLocked.json
@@ -14,7 +14,8 @@
     "preset": "_Assistant_Multi_Model_Conversational_Preset",
     "maxResponseSizeInTokens": 800,
     "addUserTurnTemplate": false,
-    "returnToUser": true
+    "returnToUser": true,
+    "addDiscussionIdTimestampsForLLM": false
   },
   {
     "title": "Workflow Lock",

--- a/Public/Configs/Workflows/assistant-multi-model/Factual-Wiki-Workflow.json
+++ b/Public/Configs/Workflows/assistant-multi-model/Factual-Wiki-Workflow.json
@@ -37,6 +37,7 @@
     "preset": "_Assistant_Multi_Model_Factual_Preset",
     "maxResponseSizeInTokens": 2000,
     "addUserTurnTemplate": false,
-    "forceGenerationPromptIfEndpointAllows": false
+    "forceGenerationPromptIfEndpointAllows": false,
+    "addDiscussionIdTimestampsForLLM": false
   }
 ]

--- a/Public/Configs/Workflows/assistant-multi-model/GetChatSummaryToolWorkflow.json
+++ b/Public/Configs/Workflows/assistant-multi-model/GetChatSummaryToolWorkflow.json
@@ -1,30 +1,15 @@
 [
   {
-    "title": "Chat Summary Memory Gathering Tool",
-    "agentName": "Chat Summary Memory Gathering Tool",
-    "type": "ChatSummaryMemoryGatheringTool",
-    "maxTurnsToPull": 30,
-    "maxSummaryChunksFromFile": 5
-  },
-  {
-    "title": "Grab the current summary from file",
-    "agentName": "Chat Summary File Puller Agent",
-    "type": "GetCurrentSummaryFromFile"
-  },
-  {
     "title": "Result Summarizer",
     "agentName": "Memory Summarizer Agent",
     "systemPrompt": "This is a request from a user that requires intelligent and careful summarization of incoming text, including a contextual understanding of what that text is truly saying. The summaries should always be clear and concise, and never allow misplaced prompt template tags, odd parentheses or brackets, or other things to negatively affect them",
-    "prompt": "A new message has been received in an online chat with a user; this could be a standard conversation between a user and an AI assistant, could be a group chat of multiple individuals (including multiple AI assistants), or could be a roleplay scenario.\nThe instructions for the conversation can be found below:\n[\n{chat_system_prompt}\n]\nAdditionally, any updates or new events to the chat scenario since it began can be found here:\n[\n{agent2Output}\n]\nSince that update was a written, more messages have come in, which have been described below:\n[\n{agent1Output}\n]\nPlease consider the instructions, the entire summary of the chat up to now, and the described new messages that have occurred since the summary was written. Please update the summary, including the new information and changes that came with the described messages in order to create a more complete summary.\nPlease respond with the complete and updated summary. The response to this request will overwrite the previous summary.",
+    "prompt": "There is currently an ongoing online conversation between a human and one or more AI users within a chat application. Information and instructions for the conversation can be found below:\n[\n{chat_system_prompt}\n]\nAs the conversation has progressed, a rolling summary of the full conversation has been getting continually updated, to allow users to keep track of everything that has said and occurred up to this point. The full summary can be found here:\n[\n[CHAT_SUMMARY]\n]\nSince that summary was last written, more messages have come in. These messages have been summarized into 'memories', which capture the most relevant information from the messages in vivid detail. The 'memories' can be found below:\n[\n[LATEST_MEMORIES]\n]\nPlease consider the instructions, the entire summary of the chat up to now, and the new 'memories' that have been generated since the summary was written. Please update the summary (or write a new one, if one does not exist) to include relevant information from the new memory; if there is already an existing summary, please duplicate as much of it as possible, modifying only as necessary to add the new knowledge. When writing a new summary, please write it as if writing the summary of a book including relevant information about the participating personas, as well as a story-like accounting of all that has occurred up to now.\nPlease respond with the complete and updated summary. The response to this request will overwrite the previous summary.",
     "endpointName": "Assistant-Multi-Model-MemoryChatSummary-Endpoint",
     "preset": "_Assistant_Multi_Model_MemoryChatSummary_Preset",
     "maxResponseSizeInTokens": 2000,
-    "addUserTurnTemplate": true
-  },
-  {
-    "title": "Save the chat summary if applicable, and return it",
-    "agentName": "Chat Summary Saver and Returner",
-    "type": "WriteCurrentSummaryToFileAndReturnIt",
-    "input": "{agent3Output}"
+    "addUserTurnTemplate": true,
+    "type": "chatSummarySummarizer",
+    "loopIfMemoriesExceed": 3,
+    "minMemoriesPerSummary": 2
   }
 ]

--- a/Public/Configs/Workflows/assistant-multi-model/MathWorkflow-LargeModel-Centric.json
+++ b/Public/Configs/Workflows/assistant-multi-model/MathWorkflow-LargeModel-Centric.json
@@ -9,6 +9,7 @@
     "preset": "_Assistant_Multi_Model_Math_Preset",
     "maxResponseSizeInTokens": 2000,
     "addUserTurnTemplate": false,
-    "forceGenerationPromptIfEndpointAllows": false
+    "forceGenerationPromptIfEndpointAllows": false,
+    "addDiscussionIdTimestampsForLLM": false
   }
 ]

--- a/Public/Configs/Workflows/assistant-multi-model/ReasoningWorkflow-LargeModel-Centric.json
+++ b/Public/Configs/Workflows/assistant-multi-model/ReasoningWorkflow-LargeModel-Centric.json
@@ -9,6 +9,7 @@
     "preset": "_Assistant_Multi_Model_Reasoning_Preset",
     "maxResponseSizeInTokens": 2000,
     "addUserTurnTemplate": false,
-    "forceGenerationPromptIfEndpointAllows": false
+    "forceGenerationPromptIfEndpointAllows": false,
+    "addDiscussionIdTimestampsForLLM": false
   }
 ]

--- a/Public/Configs/Workflows/assistant-multi-model/Technical-Workflow.json
+++ b/Public/Configs/Workflows/assistant-multi-model/Technical-Workflow.json
@@ -9,6 +9,7 @@
     "preset": "_Assistant_Multi_Model_Technical_Preset",
     "maxResponseSizeInTokens": 3000,
     "addUserTurnTemplate": false,
-    "forceGenerationPromptIfEndpointAllows": false
+    "forceGenerationPromptIfEndpointAllows": false,
+    "addDiscussionIdTimestampsForLLM": false
   }
 ]

--- a/Public/Configs/Workflows/assistant-multi-model/_DiscussionId-MemoryFile-Workflow-Settings.json
+++ b/Public/Configs/Workflows/assistant-multi-model/_DiscussionId-MemoryFile-Workflow-Settings.json
@@ -4,7 +4,6 @@
   "prompt": "A user is currently in an online conversation via a chat program; this could be a standard conversation between two a user and an AI assistant, could be a group chat of multiple individuals (including multiple AI assistants), or could be a roleplay scenario.\nThe instructions for the conversation can be found here:\n[\n{chat_system_prompt}\n]\nThe conversation so far has been summarized into 'memory' chunks as it has progressed; the current collection of those memories can be found here, if any exist:\n[\n[Memory_file]\n]\nA new series of messages have occurred since the last time those memories were updated, which can be found here:\n[\n[TextChunk]\n]\nPlease summarize the new message in the form of a single paragraph in a book, as the existing 'memories' will be update to include the exact result of this request.\nPlease use the persona/user names explicitly, as some may write in first person but the descriptions must be written in third person. Please avoid implied speech and describe the memory in vivid detail.",
   "endpointName": "Assistant-Multi-Model-MemoryChatSummary-Endpoint",
   "preset": "_Assistant_Multi_Model_MemoryChatSummary_Preset",
-  "maxResponseSizeInTokens": 400,
-  "chunkEstimatedTokenSize": 1000,
-  "chunksUntilNewMemory": 2
+  "maxResponseSizeInTokens": 250,
+  "chunkEstimatedTokenSize": 2500
 }

--- a/Public/Configs/Workflows/assistant-single-model/CodingWorkflow-LargeModel-Centric.json
+++ b/Public/Configs/Workflows/assistant-single-model/CodingWorkflow-LargeModel-Centric.json
@@ -8,6 +8,7 @@
     "endpointName": "Assistant-Single-Model-Endpoint",
     "preset": "_Assistant_Single_Model_Coder_Preset",
     "maxResponseSizeInTokens": 3000,
-    "addUserTurnTemplate": false
+    "addUserTurnTemplate": false,
+    "addDiscussionIdTimestampsForLLM": false
   }
 ]

--- a/Public/Configs/Workflows/assistant-single-model/CodingWorkflow-SmallModel-Centric.json
+++ b/Public/Configs/Workflows/assistant-single-model/CodingWorkflow-SmallModel-Centric.json
@@ -52,6 +52,7 @@
     "endpointName": "Assistant-Single-Model-Endpoint",
     "preset": "_Assistant_Single_Model_Coder_Preset",
     "maxResponseSizeInTokens": 2000,
-    "addUserTurnTemplate": false
+    "addUserTurnTemplate": false,
+    "addDiscussionIdTimestampsForLLM": false
   }
 ]

--- a/Public/Configs/Workflows/assistant-single-model/ConversationalWorkflow-New.json
+++ b/Public/Configs/Workflows/assistant-single-model/ConversationalWorkflow-New.json
@@ -15,6 +15,7 @@
     "preset": "_Assistant_Single_Model_Conversational_Preset",
     "maxResponseSizeInTokens": 800,
     "addUserTurnTemplate": false,
-    "forceGenerationPromptIfEndpointAllows": false
+    "forceGenerationPromptIfEndpointAllows": false,
+    "addDiscussionIdTimestampsForLLM": false
   }
 ]

--- a/Public/Configs/Workflows/assistant-single-model/Factual-Wiki-Workflow.json
+++ b/Public/Configs/Workflows/assistant-single-model/Factual-Wiki-Workflow.json
@@ -37,6 +37,7 @@
     "preset": "_Assistant_Single_Model_Factual_Preset",
     "maxResponseSizeInTokens": 2000,
     "addUserTurnTemplate": false,
-    "forceGenerationPromptIfEndpointAllows": false
+    "forceGenerationPromptIfEndpointAllows": false,
+    "addDiscussionIdTimestampsForLLM": false
   }
 ]

--- a/Public/Configs/Workflows/assistant-single-model/GetChatSummaryToolWorkflow.json
+++ b/Public/Configs/Workflows/assistant-single-model/GetChatSummaryToolWorkflow.json
@@ -1,30 +1,15 @@
 [
   {
-    "title": "Chat Summary Memory Gathering Tool",
-    "agentName": "Chat Summary Memory Gathering Tool",
-    "type": "ChatSummaryMemoryGatheringTool",
-    "maxTurnsToPull": 30,
-    "maxSummaryChunksFromFile": 5
-  },
-  {
-    "title": "Grab the current summary from file",
-    "agentName": "Chat Summary File Puller Agent",
-    "type": "GetCurrentSummaryFromFile"
-  },
-  {
     "title": "Result Summarizer",
     "agentName": "Memory Summarizer Agent",
     "systemPrompt": "This is a request from a user that requires intelligent and careful summarization of incoming text, including a contextual understanding of what that text is truly saying. The summaries should always be clear and concise, and never allow misplaced prompt template tags, odd parentheses or brackets, or other things to negatively affect them",
-    "prompt": "A new message has been received in an online chat with a user; this could be a standard conversation between a user and an AI assistant, could be a group chat of multiple individuals (including multiple AI assistants), or could be a roleplay scenario.\nThe instructions for the conversation can be found below:\n[\n{chat_system_prompt}\n]\nAdditionally, any updates or new events to the chat scenario since it began can be found here:\n[\n{agent2Output}\n]\nSince that update was a written, more messages have come in, which have been described below:\n[\n{agent1Output}\n]\nPlease consider the instructions, the entire summary of the chat up to now, and the described new messages that have occurred since the summary was written. Please update the summary, including the new information and changes that came with the described messages in order to create a more complete summary.\nPlease respond with the complete and updated summary. The response to this request will overwrite the previous summary.",
+    "prompt": "There is currently an ongoing online conversation between a human and one or more AI users within a chat application. Information and instructions for the conversation can be found below:\n[\n{chat_system_prompt}\n]\nAs the conversation has progressed, a rolling summary of the full conversation has been getting continually updated, to allow users to keep track of everything that has said and occurred up to this point. The full summary can be found here:\n[\n[CHAT_SUMMARY]\n]\nSince that summary was last written, more messages have come in. These messages have been summarized into 'memories', which capture the most relevant information from the messages in vivid detail. The 'memories' can be found below:\n[\n[LATEST_MEMORIES]\n]\nPlease consider the instructions, the entire summary of the chat up to now, and the new 'memories' that have been generated since the summary was written. Please update the summary (or write a new one, if one does not exist) to include relevant information from the new memory; if there is already an existing summary, please duplicate as much of it as possible, modifying only as necessary to add the new knowledge. When writing a new summary, please write it as if writing the summary of a book including relevant information about the participating personas, as well as a story-like accounting of all that has occurred up to now.\nPlease respond with the complete and updated summary. The response to this request will overwrite the previous summary.",
     "endpointName": "Assistant-Single-Model-Endpoint",
     "preset": "_Assistant_Single_Model_MemoryChatSummary_Preset",
     "maxResponseSizeInTokens": 2000,
-    "addUserTurnTemplate": true
-  },
-  {
-    "title": "Save the chat summary if applicable, and return it",
-    "agentName": "Chat Summary Saver and Returner",
-    "type": "WriteCurrentSummaryToFileAndReturnIt",
-    "input": "{agent3Output}"
+    "addUserTurnTemplate": true,
+    "type": "chatSummarySummarizer",
+    "loopIfMemoriesExceed": 3,
+    "minMemoriesPerSummary": 2
   }
 ]

--- a/Public/Configs/Workflows/assistant-single-model/MathWorkflow-LargeModel-Centric.json
+++ b/Public/Configs/Workflows/assistant-single-model/MathWorkflow-LargeModel-Centric.json
@@ -9,6 +9,7 @@
     "preset": "_Assistant_Single_Model_Math_Preset",
     "maxResponseSizeInTokens": 2000,
     "addUserTurnTemplate": false,
-    "forceGenerationPromptIfEndpointAllows": false
+    "forceGenerationPromptIfEndpointAllows": false,
+    "addDiscussionIdTimestampsForLLM": false
   }
 ]

--- a/Public/Configs/Workflows/assistant-single-model/ReasoningWorkflow-LargeModel-Centric.json
+++ b/Public/Configs/Workflows/assistant-single-model/ReasoningWorkflow-LargeModel-Centric.json
@@ -9,6 +9,7 @@
     "preset": "_Assistant_Single_Model_Reasoning_Preset",
     "maxResponseSizeInTokens": 2000,
     "addUserTurnTemplate": false,
-    "forceGenerationPromptIfEndpointAllows": false
+    "forceGenerationPromptIfEndpointAllows": false,
+    "addDiscussionIdTimestampsForLLM": false
   }
 ]

--- a/Public/Configs/Workflows/assistant-single-model/Technical-Workflow.json
+++ b/Public/Configs/Workflows/assistant-single-model/Technical-Workflow.json
@@ -9,6 +9,7 @@
     "preset": "_Assistant_Single_Model_Technical_Preset",
     "maxResponseSizeInTokens": 3000,
     "addUserTurnTemplate": false,
-    "forceGenerationPromptIfEndpointAllows": false
+    "forceGenerationPromptIfEndpointAllows": false,
+    "addDiscussionIdTimestampsForLLM": false
   }
 ]

--- a/Public/Configs/Workflows/assistant-single-model/_DiscussionId-MemoryFile-Workflow-Settings.json
+++ b/Public/Configs/Workflows/assistant-single-model/_DiscussionId-MemoryFile-Workflow-Settings.json
@@ -4,7 +4,6 @@
   "prompt": "A user is currently in an online conversation via a chat program; this could be a standard conversation between two a user and an AI assistant, could be a group chat of multiple individuals (including multiple AI assistants), or could be a roleplay scenario.\nThe instructions for the conversation can be found here:\n[\n{chat_system_prompt}\n]\nThe conversation so far has been summarized into 'memory' chunks as it has progressed; the current collection of those memories can be found here, if any exist:\n[\n[Memory_file]\n]\nA new series of messages have occurred since the last time those memories were updated, which can be found here:\n[\n[TextChunk]\n]\nPlease summarize the new message in the form of a single paragraph in a book, as the existing 'memories' will be update to include the exact result of this request.\nPlease use the persona/user names explicitly, as some may write in first person but the descriptions must be written in third person. Please avoid implied speech and describe the memory in vivid detail.",
   "endpointName": "Assistant-Single-Model-Endpoint",
   "preset": "_Assistant_Single_Model_MemoryChatSummary_Preset",
-  "maxResponseSizeInTokens": 400,
-  "chunkEstimatedTokenSize": 1000,
-  "chunksUntilNewMemory": 2
+  "maxResponseSizeInTokens": 250,
+  "chunkEstimatedTokenSize": 2500
 }

--- a/Public/Configs/Workflows/convo-roleplay-dual-model/FullCustomWorkflow-ChatSummary-Synchronous.json
+++ b/Public/Configs/Workflows/convo-roleplay-dual-model/FullCustomWorkflow-ChatSummary-Synchronous.json
@@ -14,6 +14,7 @@
     "endpointName": "Convo-Roleplay-Dual-Model-ResponderEndpoint",
     "preset": "_Convo_Roleplay_Dual_Model_Responder_Preset",
     "maxResponseSizeInTokens": 800,
-    "addUserTurnTemplate": false
+    "addUserTurnTemplate": false,
+    "addDiscussionIdTimestampsForLLM": false
   }
 ]

--- a/Public/Configs/Workflows/convo-roleplay-dual-model/FullCustomWorkflow-ChatSummary-WorkflowLocked.json
+++ b/Public/Configs/Workflows/convo-roleplay-dual-model/FullCustomWorkflow-ChatSummary-WorkflowLocked.json
@@ -14,7 +14,8 @@
     "preset": "_Convo_Roleplay_Dual_Model_Responder_Preset",
     "maxResponseSizeInTokens": 800,
     "addUserTurnTemplate": false,
-    "returnToUser": true
+    "returnToUser": true,
+    "addDiscussionIdTimestampsForLLM": false
   },
   {
     "title": "Workflow Lock",

--- a/Public/Configs/Workflows/convo-roleplay-dual-model/FullCustomWorkflow-ChatSummary.json
+++ b/Public/Configs/Workflows/convo-roleplay-dual-model/FullCustomWorkflow-ChatSummary.json
@@ -15,6 +15,7 @@
     "preset": "_Convo_Roleplay_Dual_Model_Responder_Preset",
     "maxResponseSizeInTokens": 800,
     "addUserTurnTemplate": false,
-    "forceGenerationPromptIfEndpointAllows": false
+    "forceGenerationPromptIfEndpointAllows": false,
+    "addDiscussionIdTimestampsForLLM": false
   }
 ]

--- a/Public/Configs/Workflows/convo-roleplay-dual-model/GetChatSummaryToolWorkflow.json
+++ b/Public/Configs/Workflows/convo-roleplay-dual-model/GetChatSummaryToolWorkflow.json
@@ -1,30 +1,15 @@
 [
   {
-    "title": "Chat Summary Memory Gathering Tool",
-    "agentName": "Chat Summary Memory Gathering Tool",
-    "type": "ChatSummaryMemoryGatheringTool",
-    "maxTurnsToPull": 30,
-    "maxSummaryChunksFromFile": 5
-  },
-  {
-    "title": "Grab the current summary from file",
-    "agentName": "Chat Summary File Puller Agent",
-    "type": "GetCurrentSummaryFromFile"
-  },
-  {
     "title": "Result Summarizer",
     "agentName": "Memory Summarizer Agent",
     "systemPrompt": "This is a request from a user that requires intelligent and careful summarization of incoming text, including a contextual understanding of what that text is truly saying. The summaries should always be clear and concise, and never allow misplaced prompt template tags, odd parentheses or brackets, or other things to negatively affect them",
-    "prompt": "A new message has been received in an online chat with a user; this could be a standard conversation between a user and an AI assistant, could be a group chat of multiple individuals (including multiple AI assistants), or could be a roleplay scenario.\nThe instructions for the conversation can be found below:\n[\n{chat_system_prompt}\n]\nAdditionally, any updates or new events to the chat scenario since it began can be found here:\n[\n{agent2Output}\n]\nSince that update was a written, more messages have come in, which have been described below:\n[\n{agent1Output}\n]\nPlease consider the instructions, the entire summary of the chat up to now, and the described new messages that have occurred since the summary was written. Please update the summary, including the new information and changes that came with the described messages in order to create a more complete summary.\nPlease respond with the complete and updated summary. The response to this request will overwrite the previous summary.",
+    "prompt": "There is currently an ongoing online conversation between a human and one or more AI users within a chat application. Information and instructions for the conversation can be found below:\n[\n{chat_system_prompt}\n]\nAs the conversation has progressed, a rolling summary of the full conversation has been getting continually updated, to allow users to keep track of everything that has said and occurred up to this point. The full summary can be found here:\n[\n[CHAT_SUMMARY]\n]\nSince that summary was last written, more messages have come in. These messages have been summarized into 'memories', which capture the most relevant information from the messages in vivid detail. The 'memories' can be found below:\n[\n[LATEST_MEMORIES]\n]\nPlease consider the instructions, the entire summary of the chat up to now, and the new 'memories' that have been generated since the summary was written. Please update the summary (or write a new one, if one does not exist) to include relevant information from the new memory; if there is already an existing summary, please duplicate as much of it as possible, modifying only as necessary to add the new knowledge. When writing a new summary, please write it as if writing the summary of a book including relevant information about the participating personas, as well as a story-like accounting of all that has occurred up to now.\nPlease respond with the complete and updated summary. The response to this request will overwrite the previous summary.",
     "endpointName": "Convo-Roleplay-Dual-Model-WorkerEndpoint",
     "preset": "_Convo_Roleplay_Dual_Model_Summarization_Preset",
     "maxResponseSizeInTokens": 2000,
-    "addUserTurnTemplate": true
-  },
-  {
-    "title": "Save the chat summary if applicable, and return it",
-    "agentName": "Chat Summary Saver and Returner",
-    "type": "WriteCurrentSummaryToFileAndReturnIt",
-    "input": "{agent3Output}"
+    "addUserTurnTemplate": true,
+    "type": "chatSummarySummarizer",
+    "loopIfMemoriesExceed": 3,
+    "minMemoriesPerSummary": 2
   }
 ]

--- a/Public/Configs/Workflows/convo-roleplay-dual-model/_DiscussionId-MemoryFile-Workflow-Settings.json
+++ b/Public/Configs/Workflows/convo-roleplay-dual-model/_DiscussionId-MemoryFile-Workflow-Settings.json
@@ -4,7 +4,6 @@
   "prompt": "A user is currently in an online conversation via a chat program; this could be a standard conversation between two a user and an AI assistant, could be a group chat of multiple individuals (including multiple AI assistants), or could be a roleplay scenario.\nThe instructions for the conversation can be found here:\n[\n{chat_system_prompt}\n]\nThe conversation so far has been summarized into 'memory' chunks as it has progressed; the current collection of those memories can be found here, if any exist:\n[\n[Memory_file]\n]\nA new series of messages have occurred since the last time those memories were updated, which can be found here:\n[\n[TextChunk]\n]\nPlease summarize the new message in the form of a single paragraph in a book, as the existing 'memories' will be update to include the exact result of this request.\nPlease use the persona/user names explicitly, as some may write in first person but the descriptions must be written in third person. Please avoid implied speech and describe the memory in vivid detail.",
   "endpointName": "Convo-Roleplay-Dual-Model-WorkerEndpoint",
   "preset": "_Convo_Roleplay_Dual_Model_Summarization_Preset",
-  "maxResponseSizeInTokens": 400,
-  "chunkEstimatedTokenSize": 1000,
-  "chunksUntilNewMemory": 2
+  "maxResponseSizeInTokens": 250,
+  "chunkEstimatedTokenSize": 2500
 }

--- a/Public/Configs/Workflows/convo-roleplay-single-model/FullCustomWorkflow-ChatSummary-Synchronous.json
+++ b/Public/Configs/Workflows/convo-roleplay-single-model/FullCustomWorkflow-ChatSummary-Synchronous.json
@@ -14,6 +14,7 @@
     "endpointName": "Convo-Roleplay-Single-Model-Endpoint",
     "preset": "_Convo_Roleplay_Single_Model_Responder_Preset",
     "maxResponseSizeInTokens": 800,
-    "addUserTurnTemplate": false
+    "addUserTurnTemplate": false,
+    "addDiscussionIdTimestampsForLLM": false
   }
 ]

--- a/Public/Configs/Workflows/convo-roleplay-single-model/FullCustomWorkflow-ChatSummary-WorkflowLocked.json
+++ b/Public/Configs/Workflows/convo-roleplay-single-model/FullCustomWorkflow-ChatSummary-WorkflowLocked.json
@@ -19,7 +19,8 @@
     "preset": "_Convo_Roleplay_Single_Model_Responder_Preset",
     "maxResponseSizeInTokens": 800,
     "addUserTurnTemplate": false,
-    "returnToUser": true
+    "returnToUser": true,
+    "addDiscussionIdTimestampsForLLM": false
   },
   {
     "title": "Checking AI's recent memory about this topic",

--- a/Public/Configs/Workflows/convo-roleplay-single-model/FullCustomWorkflow-ChatSummary.json
+++ b/Public/Configs/Workflows/convo-roleplay-single-model/FullCustomWorkflow-ChatSummary.json
@@ -15,6 +15,7 @@
     "preset": "_Convo_Roleplay_Single_Model_Responder_Preset",
     "maxResponseSizeInTokens": 800,
     "addUserTurnTemplate": false,
-    "forceGenerationPromptIfEndpointAllows": false
+    "forceGenerationPromptIfEndpointAllows": false,
+    "addDiscussionIdTimestampsForLLM": false
   }
 ]

--- a/Public/Configs/Workflows/convo-roleplay-single-model/GetChatSummaryToolWorkflow.json
+++ b/Public/Configs/Workflows/convo-roleplay-single-model/GetChatSummaryToolWorkflow.json
@@ -1,30 +1,15 @@
 [
   {
-    "title": "Chat Summary Memory Gathering Tool",
-    "agentName": "Chat Summary Memory Gathering Tool",
-    "type": "ChatSummaryMemoryGatheringTool",
-    "maxTurnsToPull": 30,
-    "maxSummaryChunksFromFile": 5
-  },
-  {
-    "title": "Grab the current summary from file",
-    "agentName": "Chat Summary File Puller Agent",
-    "type": "GetCurrentSummaryFromFile"
-  },
-  {
     "title": "Result Summarizer",
     "agentName": "Memory Summarizer Agent",
     "systemPrompt": "This is a request from a user that requires intelligent and careful summarization of incoming text, including a contextual understanding of what that text is truly saying. The summaries should always be clear and concise, and never allow misplaced prompt template tags, odd parentheses or brackets, or other things to negatively affect them",
-    "prompt": "A new message has been received in an online chat with a user; this could be a standard conversation between a user and an AI assistant, could be a group chat of multiple individuals (including multiple AI assistants), or could be a roleplay scenario.\nThe instructions for the conversation can be found below:\n[\n{chat_system_prompt}\n]\nAdditionally, any updates or new events to the chat scenario since it began can be found here:\n[\n{agent2Output}\n]\nSince that update was a written, more messages have come in, which have been described below:\n[\n{agent1Output}\n]\nPlease consider the instructions, the entire summary of the chat up to now, and the described new messages that have occurred since the summary was written. Please update the summary, including the new information and changes that came with the described messages in order to create a more complete summary.\nPlease respond with the complete and updated summary. The response to this request will overwrite the previous summary.",
+    "prompt": "There is currently an ongoing online conversation between a human and one or more AI users within a chat application. Information and instructions for the conversation can be found below:\n[\n{chat_system_prompt}\n]\nAs the conversation has progressed, a rolling summary of the full conversation has been getting continually updated, to allow users to keep track of everything that has said and occurred up to this point. The full summary can be found here:\n[\n[CHAT_SUMMARY]\n]\nSince that summary was last written, more messages have come in. These messages have been summarized into 'memories', which capture the most relevant information from the messages in vivid detail. The 'memories' can be found below:\n[\n[LATEST_MEMORIES]\n]\nPlease consider the instructions, the entire summary of the chat up to now, and the new 'memories' that have been generated since the summary was written. Please update the summary (or write a new one, if one does not exist) to include relevant information from the new memory; if there is already an existing summary, please duplicate as much of it as possible, modifying only as necessary to add the new knowledge. When writing a new summary, please write it as if writing the summary of a book including relevant information about the participating personas, as well as a story-like accounting of all that has occurred up to now.\nPlease respond with the complete and updated summary. The response to this request will overwrite the previous summary.",
     "endpointName": "Convo-Roleplay-Single-Model-Endpoint",
     "preset": "_Convo_Roleplay_Single_Model_MemoryChatSummary_Preset",
     "maxResponseSizeInTokens": 2000,
-    "addUserTurnTemplate": true
-  },
-  {
-    "title": "Save the chat summary if applicable, and return it",
-    "agentName": "Chat Summary Saver and Returner",
-    "type": "WriteCurrentSummaryToFileAndReturnIt",
-    "input": "{agent3Output}"
+    "addUserTurnTemplate": true,
+    "type": "chatSummarySummarizer",
+    "loopIfMemoriesExceed": 3,
+    "minMemoriesPerSummary": 2
   }
 ]

--- a/Public/Configs/Workflows/convo-roleplay-single-model/_DiscussionId-MemoryFile-Workflow-Settings.json
+++ b/Public/Configs/Workflows/convo-roleplay-single-model/_DiscussionId-MemoryFile-Workflow-Settings.json
@@ -4,7 +4,6 @@
   "prompt": "A user is currently in an online conversation via a chat program; this could be a standard conversation between two a user and an AI assistant, could be a group chat of multiple individuals (including multiple AI assistants), or could be a roleplay scenario.\nThe instructions for the conversation can be found here:\n[\n{chat_system_prompt}\n]\nThe conversation so far has been summarized into 'memory' chunks as it has progressed; the current collection of those memories can be found here, if any exist:\n[\n[Memory_file]\n]\nA new series of messages have occurred since the last time those memories were updated, which can be found here:\n[\n[TextChunk]\n]\nPlease summarize the new message in the form of a single paragraph in a book, as the existing 'memories' will be update to include the exact result of this request.\nPlease use the persona/user names explicitly, as some may write in first person but the descriptions must be written in third person. Please avoid implied speech and describe the memory in vivid detail.",
   "endpointName": "Convo-Roleplay-Single-Model-Endpoint",
   "preset": "_Convo_Roleplay_Single_Model_MemoryChatSummary_Preset",
-  "maxResponseSizeInTokens": 400,
-  "chunkEstimatedTokenSize": 1000,
-  "chunksUntilNewMemory": 2
+  "maxResponseSizeInTokens": 250,
+  "chunkEstimatedTokenSize": 2500
 }

--- a/Public/Configs/Workflows/group-chat-example/ChatGpt-4o-Workflow-OnePrompt.json
+++ b/Public/Configs/Workflows/group-chat-example/ChatGpt-4o-Workflow-OnePrompt.json
@@ -8,6 +8,7 @@
     "endpointName": "Group-Chat-Example-ChatGPT4o-Endpoint",
     "preset": "_Group_Chat_Example_ChatGPT4o_Preset",
     "maxResponseSizeInTokens": 3000,
-    "addUserTurnTemplate": false
+    "addUserTurnTemplate": false,
+    "addDiscussionIdTimestampsForLLM": false
   }
 ]

--- a/Public/Configs/Workflows/group-chat-example/Claire-TwoPrompt.json
+++ b/Public/Configs/Workflows/group-chat-example/Claire-TwoPrompt.json
@@ -19,6 +19,7 @@
     "endpointName": "Group-Chat-Example-BusinessGroup-Speaker-Endpoint",
     "preset": "_Group_Chat_Example_BusinessGroup_Speaker_Preset",
     "maxResponseSizeInTokens": 2000,
-    "addUserTurnTemplate": true
+    "addUserTurnTemplate": true,
+    "addDiscussionIdTimestampsForLLM": false
   }
 ]

--- a/Public/Configs/Workflows/group-chat-example/CustomCategorizationWorkflow.json
+++ b/Public/Configs/Workflows/group-chat-example/CustomCategorizationWorkflow.json
@@ -7,6 +7,7 @@
     "endpointName": "Group-Chat-Example-Categorization-Endpoint",
     "preset": "_Group_Chat_Example_Categorization_Preset",
     "maxResponseSizeInTokens": 100,
-    "addUserTurnTemplate": true
+    "addUserTurnTemplate": true,
+    "addDiscussionIdTimestampsForLLM": false
   }
 ]

--- a/Public/Configs/Workflows/group-chat-example/DataFinder-Factual-Workflow.json
+++ b/Public/Configs/Workflows/group-chat-example/DataFinder-Factual-Workflow.json
@@ -36,6 +36,7 @@
     "endpointName": "Group-Chat-Example-Datafinder-Endpoint",
     "preset": "_Group_Chat_Example_Datafinder_Preset",
     "maxResponseSizeInTokens": 2000,
-    "addUserTurnTemplate": false
+    "addUserTurnTemplate": false,
+    "addDiscussionIdTimestampsForLLM": false
   }
 ]

--- a/Public/Configs/Workflows/group-chat-example/Eve-TwoPrompt.json
+++ b/Public/Configs/Workflows/group-chat-example/Eve-TwoPrompt.json
@@ -19,6 +19,7 @@
     "endpointName": "Group-Chat-Example-BusinessGroup-Speaker-Endpoint",
     "preset": "_Group_Chat_Example_BusinessGroup_Speaker_Preset",
     "maxResponseSizeInTokens": 2000,
-    "addUserTurnTemplate": true
+    "addUserTurnTemplate": true,
+    "addDiscussionIdTimestampsForLLM": false
   }
 ]

--- a/Public/Configs/Workflows/group-chat-example/LePi-OnePrompt.json
+++ b/Public/Configs/Workflows/group-chat-example/LePi-OnePrompt.json
@@ -8,6 +8,7 @@
     "endpointName": "Group-Chat-Example-LePi-Endpoint",
     "preset": "_Group_Chat_Example_LePi_Preset",
     "maxResponseSizeInTokens": 2000,
-    "addUserTurnTemplate": false
+    "addUserTurnTemplate": false,
+    "addDiscussionIdTimestampsForLLM": false
   }
 ]

--- a/Public/Configs/Workflows/group-chat-example/Lex-TwoPrompt.json
+++ b/Public/Configs/Workflows/group-chat-example/Lex-TwoPrompt.json
@@ -19,6 +19,7 @@
     "endpointName": "Group-Chat-Example-BusinessGroup-Speaker-Endpoint",
     "preset": "_Group_Chat_Example_BusinessGroup_Speaker_Preset",
     "maxResponseSizeInTokens": 2000,
-    "addUserTurnTemplate": true
+    "addUserTurnTemplate": true,
+    "addDiscussionIdTimestampsForLLM": false
   }
 ]

--- a/Public/Configs/Workflows/group-chat-example/MrDramaLlama-OnePrompt.json
+++ b/Public/Configs/Workflows/group-chat-example/MrDramaLlama-OnePrompt.json
@@ -8,6 +8,7 @@
     "endpointName": "Group-Chat-Example-MrDramaLlama-Endpoint",
     "preset": "_Group_Chat_Example_MrDramaLlama_Preset",
     "maxResponseSizeInTokens": 2000,
-    "addUserTurnTemplate": false
+    "addUserTurnTemplate": false,
+    "addDiscussionIdTimestampsForLLM": false
   }
 ]

--- a/Public/Configs/Workflows/group-chat-example/MusicalMinstral-OnePrompt.json
+++ b/Public/Configs/Workflows/group-chat-example/MusicalMinstral-OnePrompt.json
@@ -8,6 +8,7 @@
     "endpointName": "Group-Chat-Example-MusicalMinstral-Endpoint",
     "preset": "_Group_Chat_Example_MusicalMinstral_Preset",
     "maxResponseSizeInTokens": 2000,
-    "addUserTurnTemplate": false
+    "addUserTurnTemplate": false,
+    "addDiscussionIdTimestampsForLLM": false
   }
 ]


### PR DESCRIPTION
The following is something that I've been working on while trying to plan out a bigger feature. This PR combines some things that are well tested and some that could use a bit more testing. Fixes and updates will follow if anyone finds anything egregiously wrong.

- Added ability to put timestamps on every message that the LLM can see; it won't be reported back to the user's frontend, but the LLM will be able to see a timestamp on every message starting from when the feature is turned on. I used this for a while and, best as I could tell, the code was working fine. However, I'm not happy with how smaller models interpret this information, so for now it is turned off on all workflows. If you want to use it, just set it to true for ALL responder nodes (so if you have a conversational workflow, coding workflow, factual workflow, etc- all of them need their responder set to true so that it will process that timestamp appropriately for every message)
- Updated how Chat Summary and Memories are generated, in order to try to make the memories more complete and contextually aware. Up until now, every memory was given only the summary + the latest messages, and because of this the memories ended up sounding a bit odd/scoped, as if they were their own little novel summary. Now, memories should be written with not only the summary, but also some of the most recently memories added in.
-  Completely revamped the RecentMemorySummarizerTool to now be useful. It pulls N number of memories starting from the latest and going backwards, and will separate them with a custom delimiter. 
 
The recentmemorysummarizertool change is still very much in testing so I haven't added this to the documentation yet, but I use this in my own chats and set the amount really high. Below is an example of the first 2 nodes from a non-workflow locked conversation workflow that I use.

```
  {
    "title": "Checking AI's recent memory about this topic",
    "agentName": "Chat Summary",
    "type": "FullChatSummary",
    "isManualConfig": true
  },
  {
    "title": "Recent memory gathering",
    "agentName": "Recent Memory Gathering Tool",
    "type": "RecentMemorySummarizerTool",
    "maxTurnsToPull": 30,
    "maxSummaryChunksFromFile": 30,
    "customDelimiter": "\n------------\n"
  },
```

So the first node will pull the recently chat summary, and the second node will pull either 30 message turns if you have no discussionid, or 30 chunks from the file if you do have a discussionid. Realistically, I can't imagine using this without a discussionid. 

So the idea here is that {agent1Output) is going to be the contents of the chatsummary file, and agent2Output will be the last N number of memories, where N is "maxSummaryChunksFromFile". If you say 5, then it'll grab the last 5 memories. In my case, I chose 30 because I just want all the memories, and figure at 100-250 tokens a pop then anything beyond that would break my context window anyhow.

Using these two combined REALLY improved my assistant's ability to keep the conversation going and track better things I had asked in the past. 

There's still more work to do on tweaking the settings here, so for now I'm not including this into the workflows yet. More to come as I can test this more heavily. 