### PR TITLE
Set up logging with rotating file handler.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 .idea
 .venv
 /venv
-logs/**/wilmerai.log
+logs/**/wilmerai.log*
 *.sqlite

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 .idea
 .venv
 /venv
-logs/*.wilmerai.log
-logs/wilmerai.log
+logs/**/wilmerai.log
 *.sqlite

--- a/Middleware/core/open_ai_api.py
+++ b/Middleware/core/open_ai_api.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import time
 import uuid
 from typing import Any, Dict, Union, List
@@ -16,6 +17,7 @@ from Middleware.workflows.managers.workflow_manager import WorkflowManager
 
 app = Flask(__name__)
 
+logger = logging.getLogger(__name__)
 
 class ModelsAPI(MethodView):
     @staticmethod
@@ -48,12 +50,12 @@ class CompletionsAPI(MethodView):
 
         :return: A JSON response if streaming is disabled, or a streaming response if enabled.
         """
-        print("CompletionsAPI request received")
+        logger.info("CompletionsAPI request received")
         data: Dict[str, Any] = request.json
-        print("CompletionsAPI request received: " + json.dumps(data))
+        logger.debug(f"CompletionsAPI request received: {json.dumps(data)}")
         prompt: str = data.get("prompt", "")
 
-        print("CompletionsAPI Processing Data")
+        logger.info("CompletionsAPI Processing Data")
         stream: bool = get_is_streaming()
         messages = parse_conversation(prompt)
 
@@ -92,7 +94,7 @@ class ChatCompletionsAPI(MethodView):
         add_user_assistant = get_is_chat_complete_add_user_assistant()
         add_missing_assistant = get_is_chat_complete_add_missing_assistant()
         request_data: Dict[str, Any] = request.get_json()
-        print("ChatCompletionsAPI request received: " + json.dumps(request_data))
+        logger.info(f"ChatCompletionsAPI request received: {json.dumps(request_data)}")
 
         # Validate the presence of the 'messages' field
         if 'messages' not in request_data:
@@ -132,7 +134,7 @@ class WilmerApi:
         self.stream: bool = True
 
     @staticmethod
-    def run_api() -> None:
+    def run_api(debug: bool) -> None:
         """
         Initializes the Flask app with the defined API endpoints and starts the server.
         """
@@ -142,7 +144,7 @@ class WilmerApi:
         app.add_url_rule('/models', view_func=ModelsAPI.as_view('models_api'))
         app.add_url_rule('/completions', view_func=CompletionsAPI.as_view('completions_api'))
         app.add_url_rule('/chat/completions', view_func=ChatCompletionsAPI.as_view('chat_completions_api'))
-        app.run(host='0.0.0.0', port=port, debug=False)
+        app.run(host='0.0.0.0', port=port, debug=debug)
 
     @staticmethod
     def handle_user_prompt(prompt_collection: List[Dict[str, str]], stream: bool) -> str:

--- a/Middleware/services/llm_service.py
+++ b/Middleware/services/llm_service.py
@@ -1,4 +1,4 @@
-import traceback
+import logging
 
 from Middleware.llmapis.kobold_llm_generate_api import KoboldApiGenerateService
 from Middleware.llmapis.open_ai_llm_chat_completions_api import OpenAiLlmChatCompletionsApiService
@@ -6,6 +6,8 @@ from Middleware.llmapis.open_ai_llm_completions_api import OpenAiLlmCompletionsA
 from Middleware.models.llm_handler import LlmHandler
 from Middleware.utilities.config_utils import get_chat_template_name, \
     get_endpoint_config, get_api_type_config
+
+logger = logging.getLogger(__name__)
 
 
 class LlmHandlerService:
@@ -15,24 +17,24 @@ class LlmHandlerService:
 
     def initialize_llm_handler(self, config_data, preset, endpoint, stream, truncate_length, max_tokens,
                                addGenerationPrompt=None):
-        print("Initialize llm hander config_data: {}".format(config_data))
+        logger.info("Initialize llm hander config_data: {}".format(config_data))
         if (addGenerationPrompt is None):
-            print("Add generation prompt is None")
+            logger.info("Add generation prompt is None")
             add_generation_prompt = config_data.get("addGenerationPrompt", False)
-            print("Add_generation_prompt: {}".format(add_generation_prompt))
+            logger.info("Add_generation_prompt: {}".format(add_generation_prompt))
         else:
-            print("Add generation prompt is {}".format(addGenerationPrompt))
-            print("Stream is {}".format(stream))
+            logger.info("Add generation prompt is {}".format(addGenerationPrompt))
+            logger.info("Stream is {}".format(stream))
             add_generation_prompt = addGenerationPrompt
         api_type_config = get_api_type_config(config_data["apiTypeConfigFileName"])
         llm_type = api_type_config["type"]
         if llm_type == "openAIV1Completion":
-            print('Loading v1 Completions endpoint: ' + endpoint)
+            logger.info('Loading v1 Completions endpoint: ' + endpoint)
             llm = OpenAiLlmCompletionsApiService(endpoint=endpoint, presetname=preset,
                                                  stream=stream, api_type_config=api_type_config,
                                                  max_tokens=max_tokens)
         elif llm_type == "openAIChatCompletion":
-            print('Loading chat Completions endpoint: ' + endpoint)
+            logger.info('Loading chat Completions endpoint: ' + endpoint)
             llm = OpenAiLlmChatCompletionsApiService(endpoint=endpoint, presetname=preset,
                                                      stream=stream, api_type_config=api_type_config,
                                                      max_tokens=max_tokens)
@@ -57,11 +59,10 @@ class LlmHandlerService:
     def load_model_from_config(self, config_name, preset, stream=False, truncate_length=4096, max_tokens=400,
                                addGenerationPrompt=None):
         try:
-            print("Loading model from: " + config_name)
+            logger.info("Loading model from: " + config_name)
             config_file = get_endpoint_config(config_name)
             return self.initialize_llm_handler(config_file, preset, config_name, stream, truncate_length, max_tokens,
                                                addGenerationPrompt)
         except Exception as e:
-            print(f"Error loading model from config: ", e)
-            traceback.print_exc()  # This prints the stack trace
+            logger.exception(f"Error loading model from config.")
             raise

--- a/Middleware/utilities/config_utils.py
+++ b/Middleware/utilities/config_utils.py
@@ -425,3 +425,13 @@ def get_is_chat_complete_add_missing_assistant() -> bool:
     """
     data = get_user_config()
     return data['chatCompletionAddMissingAssistantGenerator']
+
+
+def get_use_file_logging() -> bool:
+    """
+    Retrieves the useFileLogging configuration setting.
+    If true, Wilmer logs to a file in addition to the console.
+
+    :return: The useFileLogging setting from the user configuration.
+    """
+    return get_config_value('useFileLogging')

--- a/Middleware/utilities/instance_utils.py
+++ b/Middleware/utilities/instance_utils.py
@@ -3,3 +3,4 @@ import uuid
 INSTANCE_ID = str(uuid.uuid4())
 CONFIG_DIRECTORY = None
 USER = None
+LOGGING_DIRECTORY = "logs"

--- a/Middleware/utilities/prompt_extraction_utils.py
+++ b/Middleware/utilities/prompt_extraction_utils.py
@@ -1,5 +1,8 @@
+import logging
 import re
 from typing import Dict, Tuple, List, Optional, Any
+
+logger = logging.getLogger(__name__)
 
 template = {
     "Begin_Sys": "[Beg_Sys]",
@@ -190,7 +193,7 @@ def parse_conversation(input_string: str) -> List[Dict[str, str]]:
                     conversation.append(message)
     if beg_sys_message:
         conversation.insert(0, beg_sys_message)
-    print("Parse conversation result: ", conversation)
+    logger.debug("Parse conversation result: %s", conversation)
     return conversation
 
 

--- a/Middleware/utilities/text_utils.py
+++ b/Middleware/utilities/text_utils.py
@@ -1,6 +1,9 @@
 import re
 from copy import deepcopy
+import logging
 from typing import List, Dict
+
+logger = logging.getLogger(__name__)
 
 
 # Based on this response from ruby_coder on OpenAI forums:
@@ -241,8 +244,8 @@ def messages_to_text_block(messages: List[Dict[str, str]]) -> str:
     """
     formatted_messages = [f"{message['content']}" for message in messages]
     chunk = "\n".join(formatted_messages)
-    print("***************************************")
-    print("Chunk created: " + str(chunk))
+    logger.info("***************************************")
+    logger.info("Chunk created: " + str(chunk))
     return chunk
 
 
@@ -452,8 +455,8 @@ def replace_delimiter_in_file(filepath: str, delimit_on: str, delimit_replacer: 
         return modified_text
 
     except FileNotFoundError:
-        print(f"Error: The file at {filepath} was not found.")
+        logger.info(f"Error: The file at {filepath} was not found.")
         raise
     except IOError:
-        print(f"Error: An IOError occurred while reading the file at {filepath}.")
+        logger.info(f"Error: An IOError occurred while reading the file at {filepath}.")
         raise

--- a/Middleware/workflows/managers/workflow_variable_manager.py
+++ b/Middleware/workflows/managers/workflow_variable_manager.py
@@ -45,8 +45,9 @@ class WorkflowVariableManager:
         self.set_categories_from_kwargs(**kwargs)
 
     def apply_variables(self, prompt: str, llm_handler: Any, messages: List[Dict[str, str]],
-                        agent_outputs: Optional[Dict[str, Any]] = None, remove_all_system_override=None,
-                        config=None) -> str:
+                        agent_outputs: Optional[Dict[str, Any]] = None,
+                        remove_all_system_override = None,
+                        config: Dict = None) -> str:
         """
         Applies the generated variables to the prompt and formats it using the specified template.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,3 @@ urllib3~=2.2.2
 scikit-learn~=1.5.0
 Flask~=3.0.3
 Jinja2~=3.1.4
-ipdb~=0.13.13

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ urllib3~=2.2.2
 scikit-learn~=1.5.0
 Flask~=3.0.3
 Jinja2~=3.1.4
+ipdb~=0.13.13

--- a/server.py
+++ b/server.py
@@ -36,7 +36,7 @@ if __name__ == '__main__':
             logging.StreamHandler(),
             RotatingFileHandler(
                 "logs/wilmerai.log",
-                maxBytes=1048576 * 5,
+                maxBytes=1048576 * 3,
                 backupCount=7,
             ),
         ],

--- a/server.py
+++ b/server.py
@@ -31,6 +31,9 @@ def parse_arguments():
     if args.LoggingDirectory and args.LoggingDirectory.strip():
         instance_utils.LOGGING_DIRECTORY = args.LoggingDirectory.strip()
 
+    if "$user$" in instance_utils.LOGGING_DIRECTORY:
+        instance_utils.LOGGING_DIRECTORY = instance_utils.LOGGING_DIRECTORY.replace("$user$", instance_utils.USER)
+
 
 if __name__ == '__main__':
     parse_arguments()

--- a/server.py
+++ b/server.py
@@ -31,8 +31,8 @@ def parse_arguments():
     if args.LoggingDirectory and args.LoggingDirectory.strip():
         instance_utils.LOGGING_DIRECTORY = args.LoggingDirectory.strip()
 
-    if "$user$" in instance_utils.LOGGING_DIRECTORY:
-        instance_utils.LOGGING_DIRECTORY = instance_utils.LOGGING_DIRECTORY.replace("$user$", instance_utils.USER)
+    if "<user>" in instance_utils.LOGGING_DIRECTORY:
+        instance_utils.LOGGING_DIRECTORY = instance_utils.LOGGING_DIRECTORY.replace("<user>", instance_utils.USER)
 
 
 if __name__ == '__main__':

--- a/server.py
+++ b/server.py
@@ -1,7 +1,11 @@
 import argparse
+import logging
+from logging.handlers import RotatingFileHandler
 
 from Middleware.core.open_ai_api import WilmerApi
 from Middleware.utilities import sql_lite_utils, instance_utils
+
+logger = logging.getLogger(__name__)
 
 
 def parse_arguments():
@@ -27,12 +31,30 @@ def parse_arguments():
 if __name__ == '__main__':
     parse_arguments()
 
-    print(f"Config Directory: {instance_utils.CONFIG_DIRECTORY}")
-    print(f"User: {instance_utils.USER}")
+    logging.basicConfig(
+        handlers=[
+            logging.StreamHandler(),
+            RotatingFileHandler(
+                "logs/wilmerai.log",
+                maxBytes=1048576 * 5,
+                backupCount=7,
+            ),
+        ],
+        level=logging.DEBUG,
+        format="[%(asctime)s] %(levelname)s [%(name)s.%(funcName)s:%(lineno)d] %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S",
+    )
 
-    print(f"Deleting old locks that do not belong to Wilmer Instance_Id: '{instance_utils.INSTANCE_ID}'")
+    logger.info(f"Config Directory: {instance_utils.CONFIG_DIRECTORY}")
+    logger.info(f"User: {instance_utils.USER}")
+
+    logger.info(
+        f"Deleting old locks that do not belong to Wilmer Instance_Id: '{instance_utils.INSTANCE_ID}'"
+    )
     sql_lite_utils.SqlLiteUtils.delete_old_locks(instance_utils.INSTANCE_ID)
 
-    print("Starting API")
+    logger.info("Starting API")
+
     api = WilmerApi()
-    api.run_api()
+    # Set debug=True to enable auto-reloading.
+    api.run_api(debug=False)

--- a/server.py
+++ b/server.py
@@ -1,7 +1,7 @@
 import argparse
 import logging
 from logging.handlers import RotatingFileHandler
-
+import os
 from Middleware.core.open_ai_api import WilmerApi
 from Middleware.utilities import sql_lite_utils, instance_utils, config_utils
 
@@ -12,6 +12,7 @@ def parse_arguments():
     parser = argparse.ArgumentParser(description="Process configuration directory and user arguments.")
     parser.add_argument("--ConfigDirectory", type=str, help="Custom path to the configuration directory")
     parser.add_argument("--User", type=str, help="User to run Wilmer as")
+    parser.add_argument("--LoggingDirectory", type=str, default="logs", help="Directory for log files")
 
     parser.add_argument("positional", nargs="*", help="Positional arguments for ConfigDirectory and User")
 
@@ -27,14 +28,19 @@ def parse_arguments():
     if args.User and args.User.strip():
         instance_utils.USER = args.User.strip()
 
+    if args.LoggingDirectory and args.LoggingDirectory.strip():
+        instance_utils.LOGGING_DIRECTORY = args.LoggingDirectory.strip()
+
 
 if __name__ == '__main__':
     parse_arguments()
 
     handlers = [logging.StreamHandler()]
     if config_utils.get_use_file_logging():
+        log_directory = instance_utils.LOGGING_DIRECTORY
+        os.makedirs(log_directory, exist_ok=True)
         handlers.append(RotatingFileHandler(
-            "logs/wilmerai.log",
+            os.path.join(log_directory, "wilmerai.log"),
             maxBytes=1048576 * 3,
             backupCount=7,
         ))
@@ -48,6 +54,7 @@ if __name__ == '__main__':
 
     logger.info(f"Config Directory: {instance_utils.CONFIG_DIRECTORY}")
     logger.info(f"User: {instance_utils.USER}")
+    logger.info(f"Logging Directory: {instance_utils.LOGGING_DIRECTORY}")
 
     logger.info(
         f"Deleting old locks that do not belong to Wilmer Instance_Id: '{instance_utils.INSTANCE_ID}'"

--- a/server.py
+++ b/server.py
@@ -3,7 +3,7 @@ import logging
 from logging.handlers import RotatingFileHandler
 
 from Middleware.core.open_ai_api import WilmerApi
-from Middleware.utilities import sql_lite_utils, instance_utils
+from Middleware.utilities import sql_lite_utils, instance_utils, config_utils
 
 logger = logging.getLogger(__name__)
 
@@ -31,15 +31,16 @@ def parse_arguments():
 if __name__ == '__main__':
     parse_arguments()
 
+    handlers = [logging.StreamHandler()]
+    if config_utils.get_use_file_logging():
+        handlers.append(RotatingFileHandler(
+            "logs/wilmerai.log",
+            maxBytes=1048576 * 3,
+            backupCount=7,
+        ))
+
     logging.basicConfig(
-        handlers=[
-            logging.StreamHandler(),
-            RotatingFileHandler(
-                "logs/wilmerai.log",
-                maxBytes=1048576 * 3,
-                backupCount=7,
-            ),
-        ],
+        handlers=handlers,
         level=logging.DEBUG,
         format="[%(asctime)s] %(levelname)s [%(name)s.%(funcName)s:%(lineno)d] %(message)s",
         datefmt="%Y-%m-%d %H:%M:%S",


### PR DESCRIPTION
Switch several files from print statements to Python logging. More files can be switched over incrementally.

Individual statement levels can use some tweaking. I've set some of the really long messages to `debug` to make it easy to turn those off. Using logger.exception in catch blocks logs an error and automatically includes exception info.