### PR TITLE
Adding ImageProcessor Node

### DIFF
--- a/Middleware/core/open_ai_api.py
+++ b/Middleware/core/open_ai_api.py
@@ -225,6 +225,7 @@ class GenerateAPI(MethodView):
                 "object": "text_completion",
                 "created": current_time,
                 "model": model,
+                "response": f"{return_response}",
                 "choices": [
                     {
                         "text": f"{return_response}",
@@ -281,6 +282,12 @@ class ApiChatAPI(MethodView):
                         "role": "images",
                         "content": image_base64
                     })
+
+            if add_user_assistant:
+                if role == "user":
+                    content = "User: " + content
+                elif role == "assistant":
+                    content = "Assistant: " + content
 
             # Add the original message to the collection
             transformed_message = {"role": role, "content": content}

--- a/Middleware/models/llm_handler.py
+++ b/Middleware/models/llm_handler.py
@@ -10,3 +10,8 @@ class LlmHandler:
             self.takes_message_collection = False
         else:
             self.takes_message_collection = True
+
+        if llm_type == "ollamaApiChatImageSpecific":
+            self.takes_image_collection = True
+        else:
+            self.takes_image_collection = False

--- a/Middleware/workflows/managers/workflow_manager.py
+++ b/Middleware/workflows/managers/workflow_manager.py
@@ -408,6 +408,13 @@ class WorkflowManager:
             file = load_custom_file(filepath=filepath, delimiter=delimiter, custom_delimiter=custom_return_delimiter)
             logger.debug("Custom file result: %s", file)
             return file
+        if config.get("type") == "ImageProcessor":
+            logger.debug("Image Processor node")
+            if not any(item.get("role") == "images" for item in messages):
+                logger.debug("No images were present in the conversation collection. Returning hardcoded response.")
+                return "There were no images attached to the message"
+            prompt_processor_service = PromptProcessor(self.workflow_variable_service, self.llm_handler)
+            return prompt_processor_service.handle_image_processor_node(config, messages, agent_outputs)
 
     def handle_custom_workflow(self, config, messages, agent_outputs, stream, request_id, discussion_id):
         logger.info("Custom Workflow initiated")

--- a/Middleware/workflows/tools/parallel_llm_processing_tool.py
+++ b/Middleware/workflows/tools/parallel_llm_processing_tool.py
@@ -152,7 +152,8 @@ class ParallelLlmProcessingTool:
 
         if not llm_handler.takes_message_collection:
             result = llm_handler.llm.get_response_from_llm(system_prompt=formatted_system_prompt,
-                                                           prompt=formatted_prompt)
+                                                           prompt=formatted_prompt,
+                                                           llm_takes_images=llm_handler.takes_image_collection)
         else:
             collection = []
             if formatted_system_prompt:
@@ -160,7 +161,8 @@ class ParallelLlmProcessingTool:
             if formatted_prompt:
                 collection.append({"role": "user", "content": formatted_prompt})
 
-            result = llm_handler.llm.get_response_from_llm(collection)
+            result = llm_handler.llm.get_response_from_llm(collection,
+                                                           llm_takes_images=llm_handler.takes_image_collection)
 
         if result:
             results_queue.put((index, result))

--- a/Middleware/workflows/tools/slow_but_quality_rag_tool.py
+++ b/Middleware/workflows/tools/slow_but_quality_rag_tool.py
@@ -404,7 +404,8 @@ class SlowButQualityRAGTool:
 
         if not llm_handler.takes_message_collection:
             result = llm_handler.llm.get_response_from_llm(system_prompt=formatted_system_prompt,
-                                                           prompt=formatted_prompt)
+                                                           prompt=formatted_prompt,
+                                                           llm_takes_images=llm_handler.takes_image_collection)
         else:
             collection = []
             if formatted_system_prompt:
@@ -412,7 +413,8 @@ class SlowButQualityRAGTool:
             if formatted_prompt:
                 collection.append({"role": "user", "content": formatted_prompt})
 
-            result = llm_handler.llm.get_response_from_llm(collection)
+            result = llm_handler.llm.get_response_from_llm(collection,
+                                                           llm_takes_images=llm_handler.takes_image_collection)
 
         if result:
             return result

--- a/README.md
+++ b/README.md
@@ -93,6 +93,12 @@ WilmerAI stands for **"What If Language Models Expertly Routed All Inference?"**
   template for connections from a front end via `v1/Completions`. The template can be found in the "Docs" folder and is
   ready for upload to SillyTavern.
 
+- **Vision Multi-Modal Support Via Ollama:** Experimental support of image processing when using
+  Ollama as the front end API, and having an Ollama backend API to send it to. Functionality is available
+  to make use of this feature, which can be read about in the ImageProcessor section, but this is still being
+  tested in-depth so workflow updates will come at a later date. Support for KoboldCpp vision will be coming soon
+  as well.
+
 ## Some (Not So Pretty) Pictures to Help People Visualize What It Can Do
 
 #### Single Assistant Routing to Multiple LLMs
@@ -1127,6 +1133,45 @@ the same User, you can use the same workflow id in as many workflows as you want
 in other workflows, if that's what you desire.
 
 Workflow locks work best in multi-computer setups.
+
+### Image Processor
+
+The image processor node allows you to utilize Ollama to get information about any images sent to the backend via the
+standard Ollama images API request for either the Wilmer exposed api/chat or api/generate endpoints.
+
+So, essentially- if you connect Open WebUI to Wilmer, it will connect to an endpoint Wilmer exposes that is compatible
+with Ollama's api/chat api endpoint. If you send a picture in Open WebUI, that will be sent to Wilmer as if it were
+going to Ollama. Wilmer will see the image, and if you have an ImageProcessor node, that node will caption the image so
+that you can send it to your main text LLMs later in the workflow. The ImageProcessor node currently requires that the
+endpoint be of the `ollamaApiChatImageSpecific` ApiType, but support for KoboldCpp should be coming soon as well.
+
+In the event that no image is sent into a workflow with the ImageProcessor node, the node will return a hardcoded
+string of "There were no images attached to the message".
+
+```json
+  {
+  "title": "Image Processor",
+  "agentName": "Image Processing Agent One",
+  "type": "ImageProcessor",
+  "systemPrompt": "There is currently a conversation underway between a user and an AI Assistant in an online chat program. The AI Assistant has no ability to see images, and must rely on a written description of an image to understand what image was sent.\nWhen given an image from the user, please describe the image in vivid detail so that the AI assistant can know what image was sent and respond appropriately.",
+  "prompt": "The user has sent a new image in a chat. Please describe every aspect of the image in vivid detail. If the image appears to be a screenshot of a website or desktop application, describe not only the contents of the programs but also the general layout and UX. If it is a photo or artwork, please describe in detail the contents and any styling that can be identified. If it is a screenshot of a game that has menu options or a HUD or any sort of interactive UX, please be sure to summarize not only what is currently occurring in the screenshot but also what options appear to be available in the various UI elements. Spare no detail.",
+  "endpointName": "Socg-OpenWebUI-Image-Endpoint",
+  "preset": "_Socg_OpenWebUI_Image_Preset",
+  "maxResponseSizeInTokens": 2000,
+  "addUserTurnTemplate": true,
+  "addDiscussionIdTimestampsForLLM": true
+}
+```
+
+**IMPORTANT**: The ImageProcessor node currently does not support streaming; this only responds as non-streaming, and
+is meant to be used in the middle of a workflow as a captioner, not as the responder for a workflow.
+
+**IMPORTANT**: If you use this with Open WebUI it's fine out of the box, but if you use this in SillyTavern while
+connected to Wilmer as Text Completion -> Ollama, simply be sure to go to the 3 squares icon at the top right
+(Extensions) -> Click "Image Captioning" section, and put the Wilmer prompt template user tag in front of whatever
+caption prompt you have. So instead of the default `"What’s in this image?"` it needs to be `"[Beg_User]What’s in this
+image?"` Captioning seems to work fine with this change. I will be adding screenshots and/or a quickguide
+for this once I'm done with my testing.
 
 ## Understanding Memories
 


### PR DESCRIPTION
- Added the ImageProcessor node, which is still in testing. This allows you, when connecting a front end to Wilmer's Ollama compatible api endpoints, to send images into Wilmer and use this node to caption them in your workflow and send into other nodes as an agent output. This currently only supports an endpoint of ApiType `ollamaApiChatImageSpecific`, but I will be adding KoboldCpp's new image support soon, if possible.
- Fixed an issue with the Wilmer exposed ollama api/chat endpoint, in which it was not properly tagging user/assistant messages when the setting was set to do so.