### PR TITLE
Correcting multiple system prompt issue, and space at the end of text completion api prompts

### DIFF
--- a/Middleware/llmapis/koboldcpp_api_handler.py
+++ b/Middleware/llmapis/koboldcpp_api_handler.py
@@ -147,6 +147,7 @@ class KoboldCppApiHandler(LlmApiHandler):
                         finish_reason="stop",
                         current_username=get_current_username(),
                     )
+                    logger.debug("Total duration: {}", total_duration)
                     yield api_utils.sse_format(final_completion_json, output_format)
 
                     if output_format not in ('ollamagenerate', 'ollamaapichat'):
@@ -241,7 +242,7 @@ def prep_full_prompt(system_prompt, prompt):
         prompt = ""
     full_prompt = (system_prompt + prompt).strip()
     full_prompt = return_brackets_in_string(full_prompt)
-    full_prompt = full_prompt.strip() + " "
+    full_prompt = full_prompt.strip()
 
     logger.info("\n\n*****************************************************************************\n")
     logger.info("\n\nFormatted_Prompt: %s", full_prompt)

--- a/Middleware/llmapis/ollama_chat_api_handler.py
+++ b/Middleware/llmapis/ollama_chat_api_handler.py
@@ -136,6 +136,7 @@ class OllamaChatHandler(LlmApiHandler):
                         finish_reason="stop",
                         current_username=get_current_username(),
                     )
+                    logger.debug("Total duration: {}", total_duration)
                     yield api_utils.sse_format(final_completion_json, output_format)
 
                     if output_format not in ('ollamagenerate', 'ollamaapichat'):

--- a/Middleware/llmapis/ollama_chat_api_image_specific_handler.py
+++ b/Middleware/llmapis/ollama_chat_api_image_specific_handler.py
@@ -134,6 +134,7 @@ class OllamaApiChatImageSpecificHandler(LlmApiHandler):
                         finish_reason="stop",
                         current_username=get_current_username(),
                     )
+                    logger.debug("Total duration: {}", total_duration)
                     yield api_utils.sse_format(final_completion_json, output_format)
 
                     if output_format not in ('ollamagenerate', 'ollamaapichat'):

--- a/Middleware/llmapis/ollama_generate_api_handler.py
+++ b/Middleware/llmapis/ollama_generate_api_handler.py
@@ -139,6 +139,7 @@ class OllamaGenerateHandler(LlmApiHandler):
                         finish_reason="stop",  # Final payload explicitly includes "stop"
                         current_username=get_current_username()
                     )
+                    logger.debug("Total duration: {}", total_duration)
                     yield api_utils.sse_format(final_completion_json, output_format)
 
                     if output_format not in ('ollamagenerate', 'ollamaapichat'):
@@ -233,7 +234,7 @@ def prep_full_prompt(system_prompt, prompt):
         prompt = ""
     full_prompt = (system_prompt + prompt).strip()
     full_prompt = return_brackets_in_string(full_prompt)
-    full_prompt = full_prompt.strip() + " "
+    full_prompt = full_prompt.strip()
 
     logger.info("\n\n*****************************************************************************\n")
     logger.info("\n\nFormatted_Prompt: %s", full_prompt)

--- a/Middleware/llmapis/openai_api_handler.py
+++ b/Middleware/llmapis/openai_api_handler.py
@@ -138,6 +138,7 @@ class OpenAiApiHandler(LlmApiHandler):
                         finish_reason="stop",
                         current_username=get_current_username(),
                     )
+                    logger.debug("Total duration: {}", total_duration)
                     yield api_utils.sse_format(final_completion_json, output_format)
 
                     if output_format not in ('ollamagenerate', 'ollamaapichat'):

--- a/Middleware/llmapis/openai_completions_api_handler.py
+++ b/Middleware/llmapis/openai_completions_api_handler.py
@@ -155,6 +155,7 @@ class OpenAiCompletionsApiHandler(LlmApiHandler):
                         finish_reason="stop",  # Final payload explicitly includes "stop"
                         current_username=get_current_username()
                     )
+                    logger.debug("Total duration: {}", total_duration)
                     yield api_utils.sse_format(final_completion_json, output_format)
 
                     if output_format not in ('ollamagenerate', 'ollamaapichat'):
@@ -251,7 +252,7 @@ def prep_full_prompt(system_prompt, prompt):
         prompt = ""
     full_prompt = (system_prompt + prompt).strip()
     full_prompt = return_brackets_in_string(full_prompt)
-    full_prompt = full_prompt.strip() + " "
+    full_prompt = full_prompt.strip()
 
     logger.info("\n\n*****************************************************************************\n")
     logger.info("\n\nFormatted_Prompt: %s", full_prompt)

--- a/Middleware/utilities/prompt_extraction_utils.py
+++ b/Middleware/utilities/prompt_extraction_utils.py
@@ -176,10 +176,10 @@ def parse_conversation(input_string: str) -> List[Dict[str, str]]:
     Parses a conversation string into a list of messages with roles and content.
 
     Parameters:
-    input_string (str): The input string containing the conversation.
+        input_string (str): The input string containing the conversation.
 
     Returns:
-    List[Dict[str, str]]: The parsed list of messages.
+        List[Dict[str, str]]: The parsed list of messages.
     """
     tags = {
         "Sys": "system",
@@ -187,21 +187,25 @@ def parse_conversation(input_string: str) -> List[Dict[str, str]]:
         "User": "user",
         "Assistant": "assistant"
     }
+
+    # Regex pattern to extract role and content
+    pattern = r'\[Beg_(\w+)\](.*?)(?=\[Beg_\w+\]|$)'
+    matches = re.findall(pattern, input_string, flags=re.DOTALL)
+
     conversation = []
-    beg_sys_message = None
-    parts = input_string.split('[Beg_')
-    for part in parts[1:]:
-        if ']' in part:
-            role_key, content = part.split(']', 1)
+    sys_count = 0
+
+    for role_key, content in matches:
+        content = content.strip()
+
+        if role_key == "Sys":
+            sys_count += 1
+            role = "system" if sys_count == 1 else "systemMes"
+        else:
             role = tags.get(role_key)
-            if role:
-                message = {"role": role, "content": content.strip()}
-                if role_key == "Sys":
-                    beg_sys_message = message
-                else:
-                    conversation.append(message)
-    if beg_sys_message:
-        conversation.insert(0, beg_sys_message)
+
+        if role:
+            conversation.append({"role": role, "content": content})
     logger.debug("Parse conversation result: %s", conversation)
     return conversation
 


### PR DESCRIPTION
1. Corrected an issue with prompt_extraction_utils.py where multiple system prompts could cause issues with the parsing. 
2. Removed the added space at the end of prompts on text completion APIs.

I noticed two things while testing over the past week. 

First, that in instances of multiple system prompts being passed in on a text completion endpoint, it would cause a parsing error of the prompt. 

Second, I noticed that Mistral Small 3 was really struggling in Wilmer, and couldn't figure out why. Turns out that a little while back, while attempting to fix something else, I had injected a single space at the end of the text completion prompts to try to correct an issue where LLMs would continually add increasing spaces or newlines at the start of their response (I primarily use KoboldCpp as text completion).

In particular, I was really struggling with an issue where Mistral Small 3 would _not stop giving me emojis at the start of the response_. It was driving me up the wall. That's when I saw this post from a year ago: [https://www.reddit.com/r/LocalLLaMA/comments/167ytg3/if_all_your_text_completions_start_with_an_emoji/](https://www.reddit.com/r/LocalLLaMA/comments/167ytg3/if_all_your_text_completions_start_with_an_emoji/)

That lead me to root around in the llmapi handlers and remembered that I put that in there, as it was greatly helping with some LLMs (looking at you, gemma-2-27b...) adding newlines until the whole thing went off the rails.

Since those LLMs will likely start doing that again, I personally have started ensuring that I add the below option to my endpoint configs:

`"trimBeginningAndEndLineBreaks": true`

It's an optional property to put on your endpoints, and should lstrip the leading and trailing line breaks from the LLM. 