### PR TITLE
Disable jinja on response node

### DIFF
--- a/Public/Configs/Workflows/socg-openwebui-norouting-general-multi-model/GeneralWorkflow.json
+++ b/Public/Configs/Workflows/socg-openwebui-norouting-general-multi-model/GeneralWorkflow.json
@@ -22,6 +22,6 @@
     "maxResponseSizeInTokens": 2000,
     "addUserTurnTemplate": false,
     "addDiscussionIdTimestampsForLLM": false,
-    "jinja2": true
+    "jinja2": false
   }
 ]


### PR DESCRIPTION
Disabling jinja2 on the general multi-model response node. Not a bug, but I'm pretty sure this will confuse people, since it confused me for a moment. Jinja requires curly brackets to be doubled, so {agent1Output} would need to be {{agent1Output}}. Since the current prompt isn't making use of the jinja feature, having this on would just frustrate people. It was a mistake to push it out with that active.