### PR TITLE
Fix 500 error when offline wiki API returns 404. Added proper error h…

### DIFF
--- a/Middleware/workflows/managers/workflow_manager.py
+++ b/Middleware/workflows/managers/workflow_manager.py
@@ -277,7 +277,18 @@ class WorkflowManager:
             self.llm_handler = LlmHandler(None, get_chat_template_name(), 0, 0, True)
 
         logger.debug("Prompt processor Checkpoint")
-        logger.info("Config Type: %s", config.get("type", "No Type Found"))
+        if "type" not in config:
+            section_name = config.get("title", "Unknown")
+            valid_types = ["Standard", "ConversationMemory", "FullChatSummary", "RecentMemory", 
+                          "ConversationalKeywordSearchPerformerTool", "MemoryKeywordSearchPerformerTool", 
+                          "RecentMemorySummarizerTool", "ChatSummaryMemoryGatheringTool", "GetCurrentSummaryFromFile", 
+                          "chatSummarySummarizer", "GetCurrentMemoryFromFile", "WriteCurrentSummaryToFileAndReturnIt", 
+                          "SlowButQualityRAG", "QualityMemory", "PythonModule", "OfflineWikiApiFullArticle", 
+                          "OfflineWikiApiBestFullArticle", "OfflineWikiApiTopNFullArticles", "OfflineWikiApiPartialArticle", 
+                          "WorkflowLock", "CustomWorkflow", "ConditionalCustomWorkflow", "GetCustomFile", "ImageProcessor"]
+            logger.warning(f"Config Type: No Type Found for section '{section_name}'. Expected one of: {valid_types}")
+        else:
+            logger.info("Config Type: %s", config.get("type"))
         prompt_processor_service = PromptProcessor(self.workflow_variable_service, self.llm_handler)
 
         if "type" not in config or config["type"] == "Standard":

--- a/Middleware/workflows/processors/prompt_processor.py
+++ b/Middleware/workflows/processors/prompt_processor.py
@@ -465,24 +465,30 @@ class PromptProcessor:
         )
 
         offline_wiki_api_client = OfflineWikiApiClient()
-        if get_full_article and use_new_best_article_endpoint:
-            result = offline_wiki_api_client.get_top_full_wiki_article_by_prompt(variabled_prompt)
-            return result
-        if get_full_article and use_top_n_articles_endpoint:
-            result = offline_wiki_api_client.get_top_n_full_wiki_articles_by_prompt(variabled_prompt,
-                        percentile=percentile, num_results=num_results, top_n_articles=top_n_articles)
-            return result
-        elif get_full_article:
-            results = offline_wiki_api_client.get_full_wiki_article_by_prompt(variabled_prompt)
-        else:
-            results = offline_wiki_api_client.get_wiki_summary_by_prompt(variabled_prompt)
+        try:
+            if get_full_article and use_new_best_article_endpoint:
+                result = offline_wiki_api_client.get_top_full_wiki_article_by_prompt(variabled_prompt)
+                return result
+            if get_full_article and use_top_n_articles_endpoint:
+                result = offline_wiki_api_client.get_top_n_full_wiki_articles_by_prompt(variabled_prompt,
+                            percentile=percentile, num_results=num_results, top_n_articles=top_n_articles)
+                return result
+            elif get_full_article:
+                results = offline_wiki_api_client.get_full_wiki_article_by_prompt(variabled_prompt)
+            else:
+                results = offline_wiki_api_client.get_wiki_summary_by_prompt(variabled_prompt)
 
-        result = "No additional information provided"
-        if results is not None:
-            if len(results) > 0:
-                result = results[0]
+            result = "No additional information provided"
+            if results is not None:
+                if len(results) > 0:
+                    result = results[0]
 
-        return result
+            return result
+        except Exception as e:
+            logger.error(f"Error accessing Wikipedia information: {str(e)}")
+            search_term = variabled_prompt
+            # Return a friendly message that includes what was searched for
+            return f"I'm sorry, but I couldn't find any Wikipedia information about '{search_term}'. The information may not be available in the offline database, or there might have been an issue with the search query."
 
     def save_summary_to_file(self, config: Dict, messages: List[Dict[str, str]], discussion_id: str,
                              agent_outputs: Optional[Dict] = None, summaryOverride: str = None,

--- a/Middleware/workflows/tools/offline_wikipedia_api_tool.py
+++ b/Middleware/workflows/tools/offline_wikipedia_api_tool.py
@@ -36,7 +36,7 @@ class OfflineWikiApiClient:
             str: The text of the Wikipedia article if found, or a message if not.
 
         Raises:
-            Exception: If the API request fails.
+            Exception: If the API request fails (except for 404s which return a not found message).
         """
         if not self.use_offline_wiki_api:
             return "No additional information provided"
@@ -47,6 +47,9 @@ class OfflineWikiApiClient:
         logger.info(f"Response Text: {response.text}")
         if response.status_code == 200:
             return response.json().get('text', "No text element found")
+        elif response.status_code == 404:
+            # For 404 errors, return a message about article not being found
+            return f"No article found with title '{title}'. The information may not be available in the offline database."
         else:
             raise Exception(f"Error: {response.status_code}, {response.text}")
 
@@ -63,7 +66,7 @@ class OfflineWikiApiClient:
             list: A list of summary texts.
 
         Raises:
-            Exception: If the API request fails.
+            Exception: If the API request fails (except for 404s which return a not found message).
         """
         if not self.use_offline_wiki_api:
             return ["No additional information provided"]
@@ -80,6 +83,9 @@ class OfflineWikiApiClient:
         if response.status_code == 200:
             results = response.json()
             return [result.get('text', "No text element found") for result in results]
+        elif response.status_code == 404:
+            # For 404 errors, return a message about article not being found
+            return [f"No summaries found for '{prompt}'. The information may not be available in the offline database."]
         else:
             raise Exception(f"Error: {response.status_code}, {response.text}")
 
@@ -97,7 +103,7 @@ class OfflineWikiApiClient:
             list: A list of article texts.
 
         Raises:
-            Exception: If the API request fails.
+            Exception: If the API request fails (except for 404s which return a not found message).
         """
         if not self.use_offline_wiki_api:
             return ["No additional information provided"]
@@ -114,6 +120,9 @@ class OfflineWikiApiClient:
         if response.status_code == 200:
             results = response.json()
             return [result.get('text', "No text element found") for result in results]
+        elif response.status_code == 404:
+            # For 404 errors, return a message about article not being found
+            return [f"No articles found for '{prompt}'. The information may not be available in the offline database."]
         else:
             raise Exception(f"Error: {response.status_code}, {response.text}")
 
@@ -130,7 +139,7 @@ class OfflineWikiApiClient:
             list: A list containing the article text.
 
         Raises:
-            Exception: If the API request fails.
+            Exception: If the API request fails (except for 404s which return a not found message).
         """
         if not self.use_offline_wiki_api:
             return ["No additional information provided"]
@@ -144,9 +153,13 @@ class OfflineWikiApiClient:
         response = requests.get(url, params=params)
         logger.info(f"Response Status Code: {response.status_code}")
         logger.info(f"Response Text: {response.text}")
+        
         if response.status_code == 200:
             result = response.json()
             return [result.get('text', "No text element found")]  # Wrap the single text in a list
+        elif response.status_code == 404:
+            # For 404 errors, return a message about article not being found
+            return [f"No article found for '{prompt}'. The information may not be available in the offline database."]
         else:
             raise Exception(f"Error: {response.status_code}, {response.text}")
 
@@ -164,7 +177,7 @@ class OfflineWikiApiClient:
             list: A list containing the article text.
 
         Raises:
-            Exception: If the API request fails.
+            Exception: If the API request fails (except for 404s which return a not found message).
         """
         if not self.use_offline_wiki_api:
             return ["No additional information provided"]
@@ -182,5 +195,8 @@ class OfflineWikiApiClient:
         if response.status_code == 200:
             results = response.json()
             return [result.get('text', "No text element found") for result in results]
+        elif response.status_code == 404:
+            # For 404 errors, return a message about article not being found
+            return [f"No articles found for '{prompt}'. The information may not be available in the offline database."]
         else:
             raise Exception(f"Error: {response.status_code}, {response.text}")


### PR DESCRIPTION
…andling to return friendly error messages instead of throwing 500 errors.

Log
```

*****************************************************************************

[2025-03-28 22:53:39] INFO [Middleware.llmapis.openai_api_handler.prep_corrected_conversation:249]

Formatted_Prompt: When given an ongoing conversation, take the last messages sent and use the other messages in the conversation to expertly outline exactly what the user is asking for or saying.
Please consider the below messages:
[
User: What is iPod classic 7th gen?
Assistant:
]
In order to appropriately search for information to help respond to the user, it is important to first identify what to look up. Considering the full context of the messages provided, please specify exactly what topic the last message is speaking about. Do not simply assume that it is discussing the most recent messages; consider the entire context that has been provided and think deeply about what the user might really be saying.
[2025-03-28 22:53:39] INFO [Middleware.llmapis.openai_api_handler.prep_corrected_conversation:250]
*****************************************************************************


[2025-03-28 22:53:39] INFO [Middleware.llmapis.openai_api_handler.handle_non_streaming:181] OpenAI Chat Completions Non-Streaming flow! Attempt: 1
[2025-03-28 22:53:39] INFO [Middleware.llmapis.openai_api_handler.handle_non_streaming:182] URL: http://llm:8080/v1/chat/completions
[2025-03-28 22:53:43] INFO [Middleware.llmapis.openai_api_handler.handle_non_streaming:202]

*****************************************************************************

[2025-03-28 22:53:43] INFO [Middleware.llmapis.openai_api_handler.handle_non_streaming:203]

Output from the LLM: Based on the provided conversation, the user's last message "What is iPod classic 7th gen?" is directly asking for information about the iPod Classic 7th generation. To outline exactly what the user is asking for:

The user is seeking details about the iPod Classic 7th generation. This likely includes information such as:
- The release date and specifications of the iPod Classic 7th generation.
- Key features and capabilities of the device.
- Differences between the 7th generation and previous generations.
- Any notable changes or improvements made in the 7th generation.
- General information about its design, storage capacity, and compatibility with other devices or software.

To provide a comprehensive response, you should look up information related to the iPod Classic 7th generation, focusing on these aspects.
[2025-03-28 22:53:43] INFO [Middleware.llmapis.openai_api_handler.handle_non_streaming:204]
*****************************************************************************


[2025-03-28 22:53:43] INFO [Middleware.workflows.managers.workflow_manager.gen:146] ------Workflow GeneralWorkflow; step 1; node type: Standard
[2025-03-28 22:53:43] INFO [Middleware.workflows.managers.workflow_manager._process_section:263]

#########
Generating Wiki Api Search Query
[2025-03-28 22:53:43] INFO [Middleware.workflows.managers.workflow_manager._process_section:264]
Loading model from config Worker-Endpoint
[2025-03-28 22:53:43] INFO [Middleware.services.llm_service.load_model_from_config:47] Loading model from: Worker-Endpoint
[2025-03-28 22:53:43] INFO [Middleware.services.llm_service.initialize_llm_handler:18] Initialize llm hander config_data: {'modelNameForDisplayOnly': 'Worker Model - Mistral Small 24b - (Socg 24GB VRAM Development Machine Model)', 'endpoint': 'http://llm:8080', 'apiTypeConfigFileName': 'Open-AI-API', 'maxContextTokenSize': 16384, 'modelNameToSendToAPI': 'mistral-small-24b-instruct', 'promptTemplate': 'mistral-small-2501', 'addGenerationPrompt': True}
[2025-03-28 22:53:43] INFO [Middleware.services.llm_service.initialize_llm_handler:29] Attempting to load openAIChatCompletion endpoint: Worker-Endpoint
[2025-03-28 22:53:43] INFO [Middleware.llmapis.llm_api.__init__:47] Loading preset at /Users/seven/Documents/projects/ai/Wilmer/WilmerData/Public/Configs/Presets/OpenAiCompatibleApis/socg-openwebui-norouting-general-multi-model/Worker_Preset.json
[2025-03-28 22:53:43] WARNING [Middleware.workflows.managers.workflow_manager._process_section:289] Config Type: No Type Found for section 'Generating Wiki Api Search Query'. Expected one of: ['Standard', 'ConversationMemory', 'FullChatSummary', 'RecentMemory', 'ConversationalKeywordSearchPerformerTool', 'MemoryKeywordSearchPerformerTool', 'RecentMemorySummarizerTool', 'ChatSummaryMemoryGatheringTool', 'GetCurrentSummaryFromFile', 'chatSummarySummarizer', 'GetCurrentMemoryFromFile', 'WriteCurrentSummaryToFileAndReturnIt', 'SlowButQualityRAG', 'QualityMemory', 'PythonModule', 'OfflineWikiApiFullArticle', 'OfflineWikiApiBestFullArticle', 'OfflineWikiApiTopNFullArticles', 'OfflineWikiApiPartialArticle', 'WorkflowLock', 'CustomWorkflow', 'ConditionalCustomWorkflow', 'GetCustomFile', 'ImageProcessor']
[2025-03-28 22:53:43] INFO [Middleware.llmapis.openai_api_handler.prep_corrected_conversation:248]

*****************************************************************************

[2025-03-28 22:53:43] INFO [Middleware.llmapis.openai_api_handler.prep_corrected_conversation:249]

Formatted_Prompt: When given a series of messages from a conversation, please craft a query that will be used to find an appropriate wikipedia article that would give more factual context for the conversation provided.
When generating the query, always focus on keeping it specific and short. For example, if the latest message refers to coding in Python, it might be appropriate to generate the query 'Python programming', or when the user is asking about the television show 'House', an appropriate query may be 'House television series', or when the user is discussing Final Fantasy 14 the video game, it may be appropriate to generate several variations of the name within the query, such as 'Final Fantasy 14 FF14 Final Fantasy XIV FFXIV' Additionally, be sure to assist the search in finding higher quality results when querying ambiguous terms by adding other relevant keywords. For example, if the user is asking about 'bumblebees', be sure to include keywords like 'bumblebee insect', to avoid the search returning results for the Transformers character 'Bumblebee'.
When determining what keywords to present, please consider the full context of the conversation, thinking carefully about exactly what the user is implicitly asking rather than simply assuming they are only following up on the last message.
A new message has arrived in an ongoing online conversation. After review, the topic of the conversation as been identified, and is listed below:
[
Based on the provided conversation, the user's last message "What is iPod classic 7th gen?" is directly asking for information about the iPod Classic 7th generation. To outline exactly what the user is asking for:

The user is seeking details about the iPod Classic 7th generation. This likely includes information such as:
- The release date and specifications of the iPod Classic 7th generation.
- Key features and capabilities of the device.
- Differences between the 7th generation and previous generations.
- Any notable changes or improvements made in the 7th generation.
- General information about its design, storage capacity, and compatibility with other devices or software.

To provide a comprehensive response, you should look up information related to the iPod Classic 7th generation, focusing on these aspects.
]
Please respond with the appropriate query to search wikipedia for. Do not respond with any other text than the query, as this verbatim response will be plugged into the search engine.
[2025-03-28 22:53:43] INFO [Middleware.llmapis.openai_api_handler.prep_corrected_conversation:250]
*****************************************************************************


[2025-03-28 22:53:43] INFO [Middleware.llmapis.openai_api_handler.handle_non_streaming:181] OpenAI Chat Completions Non-Streaming flow! Attempt: 1
[2025-03-28 22:53:43] INFO [Middleware.llmapis.openai_api_handler.handle_non_streaming:182] URL: http://llm:8080/v1/chat/completions
[2025-03-28 22:53:43] INFO [Middleware.llmapis.openai_api_handler.handle_non_streaming:202]

*****************************************************************************

[2025-03-28 22:53:43] INFO [Middleware.llmapis.openai_api_handler.handle_non_streaming:203]

Output from the LLM: iPod Classic 7th generation
[2025-03-28 22:53:43] INFO [Middleware.llmapis.openai_api_handler.handle_non_streaming:204]
*****************************************************************************


[2025-03-28 22:53:43] INFO [Middleware.workflows.managers.workflow_manager.gen:146] ------Workflow GeneralWorkflow; step 2; node type: OfflineWikiApiBestFullArticle
[2025-03-28 22:53:43] INFO [Middleware.workflows.managers.workflow_manager._process_section:291] Config Type: OfflineWikiApiBestFullArticle
[2025-03-28 22:53:46] INFO [Middleware.workflows.tools.offline_wikipedia_api_tool.get_top_full_wiki_article_by_prompt:145] Response Status Code: 404
[2025-03-28 22:53:46] INFO [Middleware.workflows.tools.offline_wikipedia_api_tool.get_top_full_wiki_article_by_prompt:146] Response Text: {"detail":"No record found with title IPad Mini (7th generation)"}
[2025-03-28 22:53:46] INFO [werkzeug._log:97] 127.0.0.1 - - [28/Mar/2025 22:53:46] "POST /api/chat HTTP/1.1" 500 -
[2025-03-28 22:53:46] ERROR [werkzeug._log:97] Error on request:
Traceback (most recent call last):
  File "/Users/seven/Documents/projects/ai/Wilmer/WilmerAI/venv/lib/python3.12/site-packages/werkzeug/serving.py", line 370, in run_wsgi
    execute(self.server.app)
  File "/Users/seven/Documents/projects/ai/Wilmer/WilmerAI/venv/lib/python3.12/site-packages/werkzeug/serving.py", line 333, in execute
    for data in application_iter:
                ^^^^^^^^^^^^^^^^^
  File "/Users/seven/Documents/projects/ai/Wilmer/WilmerAI/venv/lib/python3.12/site-packages/werkzeug/wsgi.py", line 256, in __next__
    return self._next()
           ^^^^^^^^^^^^
  File "/Users/seven/Documents/projects/ai/Wilmer/WilmerAI/venv/lib/python3.12/site-packages/werkzeug/wrappers/response.py", line 32, in _iter_encoded
    for item in iterable:
                ^^^^^^^^^
  File "/Users/seven/Documents/projects/ai/Wilmer/WilmerAI/Middleware/workflows/managers/workflow_manager.py", line 211, in gen
    agent_outputs[f'agent{idx + 1}Output'] = self._process_section(config, request_id,
                                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/seven/Documents/projects/ai/Wilmer/WilmerAI/Middleware/workflows/managers/workflow_manager.py", line 372, in _process_section
    return prompt_processor_service.handle_offline_wiki_node(messages, config["promptToSearch"], agent_outputs,
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/seven/Documents/projects/ai/Wilmer/WilmerAI/Middleware/workflows/processors/prompt_processor.py", line 469, in handle_offline_wiki_node
    result = offline_wiki_api_client.get_top_full_wiki_article_by_prompt(variabled_prompt)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/seven/Documents/projects/ai/Wilmer/WilmerAI/Middleware/workflows/tools/offline_wikipedia_api_tool.py", line 151, in get_top_full_wiki_article_by_prompt
    raise Exception(f"Error: {response.status_code}, {response.text}")
Exception: Error: 404, {"detail":"No record found with title IPad Mini (7th generation)"}

```


```
Mac-mini-real% curl -X POST -H "Content-Type: application/json" -d "{\"model\": \"doesnt_matter\", \"messages\": [{\"role\": \"user\", \"content\": \"What is iPod classic 7th gen?\"}]}" http://127.0.0.1:5019/api/chat
<!doctype html>
<html lang=en>
<title>500 Internal Server Error</title>
<h1>Internal Server Error</h1>
<p>The server encountered an internal error and was unable to complete your request. Either the server is overloaded or there is an error in the application.</p>
Mac-mini-real%
```


The root cause
1. In the offline_wikipedia_api_tool.py file, when get_top_full_wiki_article_by_prompt is called and the API returns a 404 (article not found), an exception is raised: raise Exception(f"Error: {response.status_code}, {response.text}").

2. This exception is not being caught by the calling code in handle_offline_wiki_node method in the prompt_processor.py file, which directly calls the Wikipedia API functions without any error handling.

3. The workflow manager's _process_section method, which calls handle_offline_wiki_node, also doesn't have specific error handling for this case.

4. The exception propagates all the way to the API endpoint handler, causing a 500 Internal Server Error to be returned to the client.
