### PR TITLE
Fixes for sending model names to OpenAI endpoints

### DIFF
--- a/Middleware/llmapis/llm_api.py
+++ b/Middleware/llmapis/llm_api.py
@@ -60,6 +60,7 @@ class LlmApiService:
         self.endpoint_url = self.endpoint_file["endpoint"]
         self.model_name = self.endpoint_file.get("modelNameToSendToAPI", "")
         self.strip_start_stop_line_breaks = self.endpoint_file.get("trimBeginningAndEndLineBreaks", False)
+        self.dont_include_model = self.endpoint_file.get("dontIncludeModel", False)
         self.is_busy_flag: bool = False
 
         self._gen_input = preset
@@ -90,7 +91,8 @@ class LlmApiService:
                 stream=self.stream,
                 api_type_config=self.api_type_config,
                 endpoint_config=self.endpoint_file,
-                max_tokens=self.max_tokens
+                max_tokens=self.max_tokens,
+                dont_include_model=self.dont_include_model
             )
         elif self.llm_type == "koboldCppGenerate":
             return KoboldCppApiHandler(
@@ -181,7 +183,8 @@ class LlmApiService:
                  stream=self.stream,
                  api_type_config=self.api_type_config,
                  endpoint_config=self.endpoint_file,
-                 max_tokens=self.max_tokens
+                 max_tokens=self.max_tokens,
+                dont_include_model=self.dont_include_model
              )
         else:
             raise ValueError(f"Unsupported LLM type: {self.llm_type}")

--- a/Middleware/llmapis/llm_api_handler.py
+++ b/Middleware/llmapis/llm_api_handler.py
@@ -23,7 +23,8 @@ class LlmApiHandler:
             stream: bool,
             api_type_config,
             endpoint_config,
-            max_tokens
+            max_tokens,
+            dont_include_model: bool = False,
     ):
         """
         Initialize the handler with common API configuration.
@@ -53,6 +54,7 @@ class LlmApiHandler:
         self.truncate_property_name = get_config_property_if_exists("truncateLengthPropertyName", api_type_config)
         self.stream_property_name = get_config_property_if_exists("streamPropertyName", api_type_config)
         self.max_token_property_name = get_config_property_if_exists("maxNewTokensPropertyName", api_type_config)
+        self.dont_include_model = dont_include_model
 
     def handle_streaming(
             self,

--- a/Middleware/llmapis/openai_api_handler.py
+++ b/Middleware/llmapis/openai_api_handler.py
@@ -43,7 +43,11 @@ class OpenAiApiHandler(LlmApiHandler):
         corrected_conversation = prep_corrected_conversation(conversation, system_prompt, prompt)
 
         url = f"{self.base_url}/v1/chat/completions"
-        data = {"model": self.model_name, "messages": corrected_conversation, **(self.gen_input or {})}
+        data = {
+            **({"model": self.model_name} if not self.dont_include_model else {}),
+            "messages": corrected_conversation,
+            **(self.gen_input or {})
+        }
 
         add_user_assistant = get_is_chat_complete_add_user_assistant()
         add_missing_assistant = get_is_chat_complete_add_missing_assistant()
@@ -173,7 +177,11 @@ class OpenAiApiHandler(LlmApiHandler):
         corrected_conversation = prep_corrected_conversation(conversation, system_prompt, prompt)
 
         url = f"{self.base_url}/v1/chat/completions"
-        data = {"model": self.model_name, "stream": False, "messages": corrected_conversation, **(self.gen_input or {})}
+        data = {
+            **({"model": self.model_name} if not self.dont_include_model else {}),
+            "messages": corrected_conversation,
+            **(self.gen_input or {})
+        }
 
         retries: int = 3
         for attempt in range(retries):

--- a/Middleware/llmapis/openai_chat_api_image_specific_handler.py
+++ b/Middleware/llmapis/openai_chat_api_image_specific_handler.py
@@ -87,7 +87,7 @@ class OpenAIApiChatImageSpecificHandler(LlmApiHandler):
 
         url = f"{self.base_url}/v1/chat/completions"
         data = {
-            "model": self.model_name,
+            **({"model": self.model_name} if not self.dont_include_model else {}),
             "messages": corrected_conversation,
             "stream": True,
             **(self.gen_input or {})
@@ -291,7 +291,7 @@ class OpenAIApiChatImageSpecificHandler(LlmApiHandler):
 
         url = f"{self.base_url}/v1/chat/completions"
         data = {
-            "model": self.model_name,
+            **({"model": self.model_name} if not self.dont_include_model else {}),
             "messages": corrected_conversation,
             "stream": False,
             **(self.gen_input or {})


### PR DESCRIPTION
Added support for not sending the model name to openai endpoints for MLX and Llama.cpp. Will extend to Ollama later.